### PR TITLE
fix: ci needs to follow branching strategy.

### DIFF
--- a/.github/workflows/new_branch.yml
+++ b/.github/workflows/new_branch.yml
@@ -1,5 +1,5 @@
 name: CI New Branch
-run-name: CI-CD Staging
+run-name: CI-Merge New Branch
 
 # This is the CI New Branch Workflow.
 # The purpose of this workflow is to automate the process of integrating (CI) code changes

--- a/.github/workflows/new_branch.yml
+++ b/.github/workflows/new_branch.yml
@@ -1,5 +1,5 @@
 name: CI New Branch
-run-name: CI-Merge New Branch
+run-name: CI-New-Branch
 
 # This is the CI New Branch Workflow.
 # The purpose of this workflow is to automate the process of integrating (CI) code changes


### PR DESCRIPTION
As an automation developer I will map out our git branching strategy and implement the CI portion.
All pushes/merges into main will automatically be merged into staging.
A merge into staging will trigger the staging push event which in turn will do the following:
CI to run on staging. (npm ci, lint, test, coverage, build)
CI will pass build off to CD
CD will run if CI passes on staging. (currently commented out and needs more work with env vars)