### PR TITLE
Bug: README update port to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ yarn dev
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:8080](http://localhost:8080) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 


### PR DESCRIPTION
Resolves #136

Edited README.md to direct users to use localhost:8080 instead of 3000 since the port has changed in the package.json file.

