### PR TITLE
nsc-events-nextjs_2_167_creator-page-buttons

### DIFF
--- a/app/creator/creator-page.module.css
+++ b/app/creator/creator-page.module.css
@@ -1,0 +1,26 @@
+/* Creator page CSS */
+.container {
+    background-color: #bec3c8;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
+.button {
+    background-color: #08469F;
+    color: white;
+    padding: 14px;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    font-size: 1rem;
+    margin: 20px;
+    transition: background-color 0.3s ease-in-out;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), 0 6px 20px rgba(0, 0, 0, 0.3);
+}
+
+.button:hover {
+    background-color: white;
+    color:#08469F;
+  }

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -1,11 +1,16 @@
+import Link from "next/link";
+import styles from "./creator-page.module.css";
 
 const Creator = () => {
   // Temporary boilerplate code to make it compile
   return (
-      <div className="flex flex-col items-center justify-center min-h-screen">
-          <h1>Placeholder for the creator page so npm run build compiles successfully.</h1>
-           <p>FIX: move to pages or use getSession from nextauth</p>
-           <p>FIX: allow only users with creator role to be routed to this page</p>
+    <div className={styles.container}>
+        {/* <h1>Placeholder for the creator page so npm run build compiles successfully.</h1>
+          <p>FIX: move to pages or use getSession from nextauth</p>
+          <p>FIX: allow only users with creator role to be routed to this page</p> */}
+          <button className={styles.button}>Edit User Role</button>
+          <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
+          <button className={styles.button}>View Events</button>
       </div>
   );
 };

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -8,9 +8,9 @@ const Creator = () => {
         {/* <h1>Placeholder for the creator page so npm run build compiles successfully.</h1>
           <p>FIX: move to pages or use getSession from nextauth</p>
           <p>FIX: allow only users with creator role to be routed to this page</p> */}
-          <button className={styles.button}>Edit User Role</button>
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
-          <button className={styles.button}>View Events</button>
+          <button className={styles.button}>View My Events</button>
+          <button className={styles.button}>View All Events</button>
       </div>
   );
 };


### PR DESCRIPTION
Resolves #167 

I created a "Create Event" button, "View My Events", and "View All Events" button for the creator page. The "Create Event" button redirects to the Create Event page.

I added basic CSS styling to match the style of the web app's Home page, with NSC Events theme colors for the buttons (like the android app's AdminView page).

<img width="943" alt="Screenshot 2024-02-05 061314" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/0b75b35e-2103-4342-b83f-099a150a79af">

Related to User Story #166 

