### PR TITLE
nsc-events-nextjs_2_184_update-page.tsx

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -1,5 +1,4 @@
-"use client";
-import { ChangeEventHandler, FormEventHandler, useState } from "react";
+"use client";import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import {
   Container,
   Paper,
@@ -186,7 +185,10 @@ const SignUp = () => {
             InputProps={{
               endAdornment: (
                 <InputAdornment position="end">
-                  <IconButton onClick={togglePasswordVisibility}>
+                  <IconButton
+                    aria-label="toggle passworld"
+                    onClick={togglePasswordVisibility}
+                  >
                     {showPassword ? <VisibilityOff /> : <Visibility />}
                   </IconButton>
                 </InputAdornment>
@@ -206,7 +208,10 @@ const SignUp = () => {
             InputProps={{
               endAdornment: (
                 <InputAdornment position="end">
-                  <IconButton onClick={toggleConfirmPasswordVisibility}>
+                  <IconButton
+                    aria-label="toggle passworld"
+                    onClick={toggleConfirmPasswordVisibility}
+                  >
                     {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
                   </IconButton>
                 </InputAdornment>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -186,7 +186,7 @@ const SignUp = () => {
               endAdornment: (
                 <InputAdornment position="end">
                   <IconButton
-                    aria-label="toggle passworld"
+                    aria-label="toggle password"
                     onClick={togglePasswordVisibility}
                   >
                     {showPassword ? <VisibilityOff /> : <Visibility />}
@@ -209,7 +209,7 @@ const SignUp = () => {
               endAdornment: (
                 <InputAdornment position="end">
                   <IconButton
-                    aria-label="toggle passworld"
+                    aria-label="toggle password"
                     onClick={toggleConfirmPasswordVisibility}
                   >
                     {showConfirmPassword ? <VisibilityOff /> : <Visibility />}


### PR DESCRIPTION
I updated the password visibility icons on the signup page to include aria-labels for screen readers.
This is considered best practices for accessibility and to help people with screen readers navigate better.

Resolves #184 


