### PR TITLE
nsc-events-nextjs-3-198-and-199-standardize-button-colors-and-input-field-styles

### DIFF
--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,7 +1,8 @@
 "use client";
+
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
 import { Box, Button, TextField, Typography, Container, Paper } from '@mui/material';
-
+import { textFieldStyle } from "@/components/InputFields"
 
 const ForgotPassword = () => {
   
@@ -43,12 +44,14 @@ const ForgotPassword = () => {
             autoFocus
             value={email}
             onChange={handleChange}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <Button
             type="submit"
             fullWidth
             variant="contained"
-            color="secondary"
+            color="primary"
             sx={{ mt: 3, mb: 2 }}
             style={{ textTransform: 'none' }}
           >

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import Image from "next/image";
 import logo from "../../logo.png";
 import { Container, Paper, Box, TextField, Button, Typography, Link as MuiLink } from "@mui/material";
-
+import { textFieldStyle } from "@/components/InputFields"
 
 // similar to sign-up page, but we're only handling email and password 
 const Signin = () => {
@@ -72,6 +72,8 @@ const Signin = () => {
             autoFocus
             value={userInfo.email}
             onChange={handleChange}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             margin="normal"
@@ -84,10 +86,12 @@ const Signin = () => {
             autoComplete="current-password"
             value={userInfo.password}
             onChange={handleChange}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <Button
             style={{ textTransform: 'none' }}
-            color="secondary"
+            color="primary"
             type="submit"
             fullWidth
             variant="contained"

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -1,4 +1,7 @@
-"use client";import { ChangeEventHandler, FormEventHandler, use, useState } from "react";import {  Container,
+"use client";
+
+import { ChangeEventHandler, FormEventHandler, use, useState } from "react";
+import {  Container,
   Paper,
   Box,
   TextField,
@@ -8,6 +11,7 @@
   Typography,
   Link as MuiLink,
 } from "@mui/material";
+import { textFieldStyle } from "@/components/InputFields"
 import Snackbar, { SnackbarOrigin } from "@mui/material/Snackbar";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
@@ -152,6 +156,8 @@ const SignUp = () => {
             onChange={handleChange}
             error={Boolean(errors.firstName)}
             helperText={errors.firstName}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             fullWidth
@@ -162,6 +168,8 @@ const SignUp = () => {
             onChange={handleChange}
             error={Boolean(errors.lastName)}
             helperText={errors.lastName}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             fullWidth
@@ -172,6 +180,8 @@ const SignUp = () => {
             onChange={handleChange}
             error={Boolean(errors.email)}
             helperText={errors.email}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             fullWidth
@@ -183,7 +193,9 @@ const SignUp = () => {
             onChange={handleChange}
             error={Boolean(errors.password)}
             helperText={errors.password}
+            InputLabelProps={{ style: textFieldStyle.label }} 
             InputProps={{
+              style: textFieldStyle.input, 
               endAdornment: (
                 <InputAdornment position="end">
                   <IconButton onClick={togglePasswordVisibility}>
@@ -203,7 +215,9 @@ const SignUp = () => {
             onChange={handleChange}
             error={Boolean(errors.confirmPassword)}
             helperText={errors.confirmPassword}
+            InputLabelProps={{ style: textFieldStyle.label }} 
             InputProps={{
+              style: textFieldStyle.input, 
               endAdornment: (
                 <InputAdornment position="end">
                   <IconButton onClick={toggleConfirmPasswordVisibility}>

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -1,15 +1,14 @@
 'use client';
 import { createTheme } from '@mui/material/styles';
-import { blue, green } from '@mui/material/colors';
 
 const theme = createTheme({
   // Customize your theme here
   palette: {
     primary: {
-      main: blue[800], //alternatively '#1565c0'
+      main: '#08469f',
     },
     secondary: {
-      main: green[500], 
+      main: '#95ca59',  
     },
     // Add additional theme configurations as needed
   },

--- a/components/InputFields.tsx
+++ b/components/InputFields.tsx
@@ -3,6 +3,20 @@ import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import IconButton from '@mui/material/IconButton';
 
+export const textFieldStyle = {
+  input: {
+    color: 'black', 
+    backgroundColor: 'white', 
+    '&::placeholder': {
+      color: 'black', 
+    },
+  },
+  label: {
+    color: 'black', 
+    fontSize: '1.1rem', 
+  },
+};
+
 interface InputFieldProps {
   label: string;
   type: string;


### PR DESCRIPTION
Resolves: #199 #198 
Relates to: #196 

## Changes
- **Input Fields**: Implemented a unified style for all text fields and their labels. The new style features:
- **Buttons**: Standardized the color of all buttons and Nav bar to the same shade of blue
- **Code Reusability**: Centralized the styling of input fields into an exportable `textFieldStyle` object. 

![Screenshot 2024-02-16 at 9 28 24 PM](https://github.com/SeattleColleges/nsc-events-nextjs/assets/55855783/5f89b9e8-62b6-4322-8c65-c39d79eb516d)
![Screenshot 2024-02-16 at 9 27 08 PM](https://github.com/SeattleColleges/nsc-events-nextjs/assets/55855783/586e1f11-a543-4d25-9e2f-5da816418423)
![Screenshot 2024-02-16 at 9 28 39 PM](https://github.com/SeattleColleges/nsc-events-nextjs/assets/55855783/ca623621-4652-4556-b636-8020414287da)
