### PR TITLE
nsc-events-nextjs_3_205_refactor-create-event-page

### DIFF
--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -12,7 +12,7 @@ import "react-clock/dist/Clock.css";
 //import TextField, { TextFieldProps } from '@mui/material/TextField';
 // import { format, parse } from 'date-fns';
 import InputField from "@/components/InputFields";
-import {TextField, Box, Button, Typography, Stack }  from '@mui/material';
+import { TextField, Box, Button, Typography, Stack }  from '@mui/material';
 
 
 const CreateEvent: React.FC = () => {

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -7,37 +7,12 @@ import ImagePicker from "@/components/ImagePicker";
 import "react-datepicker/dist/react-datepicker.css";
 import "react-time-picker/dist/TimePicker.css";
 import "react-clock/dist/Clock.css";
-import { createTheme, ThemeProvider } from '@mui/material/styles';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Typography from "@mui/material/Typography";
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import { LocalizationProvider, TimePicker } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import TextField, { TextFieldProps } from '@mui/material/TextField';
+//import { LocalizationProvider, TimePicker } from '@mui/x-date-pickers';
+//import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+//import TextField, { TextFieldProps } from '@mui/material/TextField';
 // import { format, parse } from 'date-fns';
 import InputField from "@/components/InputFields";
-
-
-// custom theme
-const createEventTheme = createTheme({
-  components: {
-    MuiTextField: {
-      styleOverrides: {
-        root: {
-          '& label': { color: 'white' },
-          '& .MuiInputBase-input': { color: 'white' },
-          '& .MuiOutlinedInput-root': {
-            '& fieldset': { borderColor: 'white' },
-            '&:hover fieldset': { borderColor: 'white' },
-            '&.Mui-focused fieldset': { borderColor: 'white' },
-          },
-        },
-      },
-    },
-  },
-});
+import {TextField, Box, Button, Typography, Stack }  from '@mui/material';
 
 
 const CreateEvent: React.FC = () => {
@@ -57,7 +32,6 @@ const CreateEvent: React.FC = () => {
     timeError
   } = useEventForm(activityAutofill);
 
-
     // // Convert startTime and endTime from string to Date for TimePicker
     // const startTimeDate = startTime ? parse(startTime, 'HH:mm', new Date()) : null;
     // const endTimeDate = endTime ? parse(endTime, 'HH:mm', new Date()) : null;
@@ -73,534 +47,281 @@ const CreateEvent: React.FC = () => {
     //   handleEndTimeChange(timeStr);
     // };
 
-
   return (
-    <ThemeProvider theme={createEventTheme}>
-      {/* <LocalizationProvider dateAdapter={AdapterDateFns}> */}
-        <Box sx={{ p: 3 }}>
-          <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', color: 'white', mb: 2 }}>
-              Add Event
-          </Typography>
-            <Box
-              component="form"
-              noValidate
-              autoComplete="off"
-              onSubmit={handleSubmit}
-              sx={{ '& .MuiFormControl-root': { mb: 2, width: '100%' } }}
-            >
+   //<LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3 }}>
+        <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', color: 'white', mb: 2 }}>
+            Add Event
+        </Typography>
+        <Stack spacing={2}> 
+          <TextField
+            id="event-title"
+            label="Event Title"
+            variant="outlined"
+            name="eventTitle"
+            value={eventData.eventTitle}
+            onChange={handleInputChange}
+            error={!!errors.eventTitle}
+            helperText={errors.eventTitle}
+          />
+          <TextField
+            id="event-description"
+            label="Event Description"
+            variant="outlined"
+            name="eventDescription"
+            value={eventData.eventDescription}
+            onChange={handleInputChange}
+            error={!!errors.eventDescription}
+            helperText={errors.eventDescription}
+          />
+          <TextField
+            id="event-category"
+            label="Event Category"
+            variant="outlined"
+            name="eventCategory"
+            value={eventData.eventCategory}
+            onChange={handleInputChange}
+            error={!!errors.eventCategory}
+            helperText={errors.eventCategory} 
+          />
+          <div className="mt-1">
+            <label className="block text-sm font-medium text-white-700">
+              Event Date
+            </label>
+            <Datepicker
+              selected={selectedDate}
+              onChange={(date) => setSelectedDate(date)}
+              minDate={new Date()}
+              showMonthDropdown
+              showYearDropdown
+              dropdownMode="select"
+              dateFormat={"MM-dd-yyyy"}
+              placeholderText="Select Date"
+            />
+          </div>
 
-              <FormControl variant="outlined" size="small">
-                <InputLabel htmlFor="event-title">Event Title</InputLabel>
-                  <TextField
-                    id="event-title"
-                    label="Event Title"
-                    variant="outlined"
-                    name="eventTitle"
-                    value={eventData.eventTitle}
-                    onChange={handleInputChange}
-                    error={!!errors.eventTitle}
-                    helperText={errors.eventTitle}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-                
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-description">Event Description</InputLabel>
-                  <TextField
-                    id="event-description"
-                    label="Event Description"
-                    variant="outlined"
-                    name="eventDescription"
-                    value={eventData.eventDescription}
-                    onChange={handleInputChange}
-                    error={!!errors.eventDescription}
-                    helperText={errors.eventDescription}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-            
-              <FormControl variant="outlined" size="small">   
-                <InputLabel htmlFor="event-category">Event Category</InputLabel>
-                  <TextField
-                    id="event-category"
-                    label="Event Category"
-                    variant="outlined"
-                    name="eventCategory"
-                    value={eventData.eventCategory}
-                    onChange={handleInputChange}
-                    error={!!errors.eventCategory}
-                    helperText={errors.eventCategory}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
+          <InputField
+            label="Start Time"
+            type="time"
+            name="startTime"
+            value={startTime || ""}
+            onChange={(time) => handleStartTimeChange(time.target.value)}
+          />
+          <InputField
+            label="End Time"
+            type="time"
+            name="endTime"
+            value={endTime || ""}
+            onChange={(time) => handleEndTimeChange(time.target.value)}
+          />
 
-              <div className="mt-1">
-                <label className="block text-sm font-medium text-white-700">
-                  Event Date
-                </label>
-                <Datepicker
-                  selected={selectedDate}
-                  onChange={(date) => setSelectedDate(date)}
-                  minDate={new Date()}
-                  showMonthDropdown
-                  showYearDropdown
-                  dropdownMode="select"
-                  dateFormat={"MM-dd-yyyy"}
-                  placeholderText="Select Date"
-                />
-              </div>
-
-              <InputField
-                label="Start Time"
-                type="time"
-                name="startTime"
-                value={startTime || ""}
-                onChange={(time) => handleStartTimeChange(time.target.value)}
-              />
-              <InputField
-                label="End Time"
-                type="time"
-                name="endTime"
-                value={endTime || ""}
-                onChange={(time) => handleEndTimeChange(time.target.value)}
-              />
-
-              {/* <TimePicker
-                label="Start Time"
-                value={startTimeDate}
-                onChange={onStartTimeChange}
-                renderInput={(params: TextFieldProps) => <TextField {...params} error={!!timeError} helperText={timeError} />}
-              />
-              <TimePicker
-                label="End Time"
-                value={endTimeDate}
-                onChange={onEndTimeChange}
-                renderInput={(params: TextFieldProps) => <TextField {...params} error={!!timeError} helperText={timeError} />}
-              /> */}
-              {/* Time Error Message */}
-              {timeError && (
-                <div className="text-red-500 text-sm mt-2">{timeError}</div>
-              )}
-              <div className="space-y-2">
-                <TagSelector
-                  selectedTags={eventData.eventTags}
-                  allTags={[
-                    "Professional Development",
-                    "Social",
-                    "Tech",
-                    "Conference",
-                    "Networking",
-                    "Pizza",
-                    "LGBTQIA",
-                  ]}
-                  onTagClick={handleTagClick}
-                />
-              </div>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-location">Event Location</InputLabel>
-                  <TextField
-                    id="event-location"
-                    label="Event Location"
-                    variant="outlined"
-                    name="eventLocation"
-                    value={eventData.eventLocation}
-                    onChange={handleInputChange}
-                    error={!!errors.eventLocation}
-                    helperText={errors.eventLocation}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <label>
-                Event Cover Photo
-                <ImagePicker/>
-              </label>
-                
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-host">Event Host</InputLabel>
-                  <TextField
-                    id="event-host"
-                    label="Event Host"
-                    variant="outlined"
-                    name="eventHost"
-                    value={eventData.eventHost}
-                    onChange={handleInputChange}
-                    error={!!errors.eventHost}
-                    helperText={errors.eventHost}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-website">Event Website</InputLabel>
-                  <TextField
-                    id="event-website"
-                    label="Event Website"
-                    variant="outlined"
-                    name="eventWebsite"
-                    value={eventData.eventWebsite}
-                    onChange={handleInputChange}
-                    error={!!errors.eventWebsite}
-                    helperText={errors.eventWebsite}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-registration">Event Registration</InputLabel>
-                  <TextField
-                    id="event-registration"
-                    label="Event Registration"
-                    variant="outlined"
-                    name="eventRegistration"
-                    value={eventData.eventRegistration}
-                    onChange={handleInputChange}
-                    error={!!errors.eventRegistration}
-                    helperText={errors.eventRegistration}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-capacity">Event Capacity</InputLabel>
-                  <TextField
-                    id="event-capacity"
-                    label="Event Capacity"
-                    variant="outlined"
-                    name="eventCapacity"
-                    value={eventData.eventCapacity}
-                    onChange={handleInputChange}
-                    error={!!errors.eventCapacity}
-                    helperText={errors.eventCapacity}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-cost">Event Cost</InputLabel>
-                  <TextField
-                    id="event-cost"
-                    label="Event Cost"
-                    variant="outlined"
-                    name="eventCost"
-                    value={eventData.eventCost}
-                    onChange={handleInputChange}
-                    error={!!errors.eventCost}
-                    helperText={errors.eventCost}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-schedule">Event Schedule</InputLabel>
-                  <TextField
-                    id="event-schedule"
-                    label="Event Schedule"
-                    variant="outlined"
-                    name="eventSchedule"
-                    value={eventData.eventSchedule}
-                    onChange={handleInputChange}
-                    error={!!errors.eventSchedule}
-                    helperText={errors.eventSchedule}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-speakers">Event Speakers</InputLabel>
-                  <TextField
-                    id="event-speakers"
-                    label="Event Speakers"
-                    variant="outlined"
-                    name="eventSpeakers"
-                    value={eventData.eventSpeakers}
-                    onChange={handleInputChange}
-                    error={!!errors.eventSpeakers}
-                    helperText={errors.eventSpeakers}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-prerequisites">Event Prerequisites</InputLabel>
-                  <TextField
-                    id="event-prerequisites"
-                    label="Event Prerequisites"
-                    variant="outlined"
-                    name="eventPrerequisites"
-                    value={eventData.eventPrerequisites}
-                    onChange={handleInputChange}
-                    error={!!errors.eventPrerequisites}
-                    helperText={errors.eventPrerequisites}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-cancellation-policy">Event Cancellation Policy</InputLabel>
-                  <TextField
-                    id="event-cancellation-policy"
-                    label="Event CancellationPolicy"
-                    variant="outlined"
-                    name="eventCancellationPolicy"
-                    value={eventData.eventCancellationPolicy}
-                    onChange={handleInputChange}
-                    error={!!errors.eventCancellationPolicy}
-                    helperText={errors.eventCancellationPolicy}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-contact">Event Contact</InputLabel>
-                  <TextField
-                    id="event-contact"
-                    label="Event Contact"
-                    variant="outlined"
-                    name="eventContact"
-                    value={eventData.eventContact}
-                    onChange={handleInputChange}
-                    error={!!errors.eventContact}
-                    helperText={errors.eventContact}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="facebook">Facebook</InputLabel>
-                  <TextField
-                    id="facebook"
-                    label="Facebook"
-                    variant="outlined"
-                    name="facebook"
-                    value={eventData.eventSocialMedia.facebook || ''}
-                    onChange={(e) => handleSocialMediaChange('facebook', e.target.value)}
-                    error={!!errors.eventSocialMedia?.facebook}
-                    helperText={errors.eventSocialMedia?.facebook}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="twitter">Twitter</InputLabel>
-                  <TextField
-                    id="twitter"
-                    label="Twitter"
-                    variant="outlined"
-                    name="twitter"
-                    value={eventData.eventSocialMedia.twitter || ''}
-                    onChange={(e) => handleSocialMediaChange('twitter', e.target.value)}
-                    error={!!errors.eventSocialMedia?.twitter}
-                    helperText={errors.eventSocialMedia?.twitter}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="instagram">Instagram</InputLabel>
-                  <TextField
-                    id="instagram"
-                    label="Instagram"
-                    variant="outlined"
-                    name="instagram"
-                    value={eventData.eventSocialMedia.instagram || ''}
-                    onChange={(e) => handleSocialMediaChange('instagram', e.target.value)}
-                    error={!!errors.eventSocialMedia?.instagram}
-                    helperText={errors.eventSocialMedia?.instagram}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="hashtag">Hashtag</InputLabel>
-                  <TextField
-                    id="hashtag"
-                    label="Hashtag"
-                    variant="outlined"
-                    name="hashtag"
-                    value={eventData.eventSocialMedia.hashtag || ''}
-                    onChange={(e) => handleSocialMediaChange('hashtag', e.target.value)}
-                    error={!!errors.eventSocialMedia?.hashtag}
-                    helperText={errors.eventSocialMedia?.hashtag}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-                
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-privacy">Event Privacy</InputLabel>
-                  <TextField
-                    id="event-privacy"
-                    label="Event Privacy"
-                    variant="outlined"
-                    name="eventPrivacy"
-                    value={eventData.eventPrivacy}
-                    onChange={handleInputChange}
-                    error={!!errors.eventPrivacy}
-                    helperText={errors.eventPrivacy}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
-              <FormControl variant="outlined" size="small"> 
-                <InputLabel htmlFor="event-accessibility">Event Accessibility</InputLabel>
-                  <TextField
-                    id="event-accessibility"
-                    label="Event Accessibility"
-                    variant="outlined"
-                    name="eventAccessibility"
-                    value={eventData.eventAccessibility}
-                    onChange={handleInputChange}
-                    error={!!errors.eventAccessibility}
-                    helperText={errors.eventAccessibility}
-                    sx={{
-                      '& .MuiInputLabel-outlined': {
-                        transform: 'translate(14px, 14px) scale(1)', // Adjust label position
-                        '&.MuiInputLabel-shrink': {
-                          transform: 'translate(14px, -6px) scale(0.75)', // Adjust label position when focused
-                        },
-                      },
-                    }}
-                  />
-              </FormControl>
-
+          {/* <TimePicker
+            label="Start Time"
+            value={startTimeDate}
+            onChange={onStartTimeChange}
+            renderInput={(params: TextFieldProps) => <TextField {...params} error={!!timeError} helperText={timeError} />}
+          />
+          <TimePicker
+            label="End Time"
+            value={endTimeDate}
+            onChange={onEndTimeChange}
+            renderInput={(params: TextFieldProps) => <TextField {...params} error={!!timeError} helperText={timeError} />}
+          /> */}
+          {/* Time Error Message */}
+          {timeError && (
+            <div className="text-red-500 text-sm mt-2">{timeError}</div>
+          )}
+          <TagSelector
+            selectedTags={eventData.eventTags}
+            allTags={[
+              "Professional Development",
+              "Social",
+              "Tech",
+              "Conference",
+              "Networking",
+              "Pizza",
+              "LGBTQIA",
+            ]}
+            onTagClick={handleTagClick}
+          />
+          <TextField
+            id="event-location"
+            label="Event Location"
+            variant="outlined"
+            name="eventLocation"
+            value={eventData.eventLocation}
+            onChange={handleInputChange}
+            error={!!errors.eventLocation}
+            helperText={errors.eventLocation}
+          />
+          <label>
+            Event Cover Photo
+          <ImagePicker/>
+          </label>
+          <TextField
+            id="event-host"
+            label="Event Host"
+            variant="outlined"
+            name="eventHost"
+            value={eventData.eventHost}
+            onChange={handleInputChange}
+            error={!!errors.eventHost}
+            helperText={errors.eventHost} 
+          />
+          <TextField
+            id="event-website"
+            label="Event Website"
+            variant="outlined"
+            name="eventWebsite"
+            value={eventData.eventWebsite}
+            onChange={handleInputChange}
+            error={!!errors.eventWebsite}
+            helperText={errors.eventWebsite} 
+          />
+          <TextField
+            id="event-registration"
+            label="Event Registration"
+            variant="outlined"
+            name="eventRegistration"
+            value={eventData.eventRegistration}
+            onChange={handleInputChange}
+            error={!!errors.eventRegistration}
+            helperText={errors.eventRegistration}
+          />
+          <TextField
+            id="event-capacity"
+            label="Event Capacity"
+            variant="outlined"
+            name="eventCapacity"
+            value={eventData.eventCapacity}
+            onChange={handleInputChange}
+            error={!!errors.eventCapacity}
+            helperText={errors.eventCapacity}
+          />
+          <TextField
+            id="event-cost"
+            label="Event Cost"
+            variant="outlined"
+            name="eventCost"
+            value={eventData.eventCost}
+            onChange={handleInputChange}
+            error={!!errors.eventCost}
+            helperText={errors.eventCost}
+          />
+          <TextField
+            id="event-schedule"
+            label="Event Schedule"
+            variant="outlined"
+            name="eventSchedule"
+            value={eventData.eventSchedule}
+            onChange={handleInputChange}
+            error={!!errors.eventSchedule}
+            helperText={errors.eventSchedule}
+          />
+          <TextField
+            id="event-speakers"
+            label="Event Speakers"
+            variant="outlined"
+            name="eventSpeakers"
+            value={eventData.eventSpeakers}
+            onChange={handleInputChange}
+            error={!!errors.eventSpeakers}
+            helperText={errors.eventSpeakers}
+          />
+          <TextField
+            id="event-prerequisites"
+            label="Event Prerequisites"
+            variant="outlined"
+            name="eventPrerequisites"
+            value={eventData.eventPrerequisites}
+            onChange={handleInputChange}
+            error={!!errors.eventPrerequisites}
+            helperText={errors.eventPrerequisites}                 
+          />
+          <TextField
+            id="event-cancellation-policy"
+            label="Event CancellationPolicy"
+            variant="outlined"
+            name="eventCancellationPolicy"
+            value={eventData.eventCancellationPolicy}
+            onChange={handleInputChange}
+            error={!!errors.eventCancellationPolicy}
+            helperText={errors.eventCancellationPolicy}
+          />
+          <TextField
+            id="event-contact"
+            label="Event Contact"
+            variant="outlined"
+            name="eventContact"
+            value={eventData.eventContact}
+            onChange={handleInputChange}
+            error={!!errors.eventContact}
+            helperText={errors.eventContact}         
+          />
+          <TextField
+            id="facebook"
+            label="Facebook"
+            variant="outlined"
+            name="facebook"
+            value={eventData.eventSocialMedia.facebook || ''}
+            onChange={(e) => handleSocialMediaChange('facebook', e.target.value)}
+            error={!!errors.eventSocialMedia?.facebook}
+            helperText={errors.eventSocialMedia?.facebook}         
+          />
+          <TextField
+            id="twitter"
+            label="Twitter"
+            variant="outlined"
+            name="twitter"
+            value={eventData.eventSocialMedia.twitter || ''}
+            onChange={(e) => handleSocialMediaChange('twitter', e.target.value)}
+            error={!!errors.eventSocialMedia?.twitter}
+            helperText={errors.eventSocialMedia?.twitter}
+          />
+          <TextField
+            id="instagram"
+            label="Instagram"
+            variant="outlined"
+            name="instagram"
+            value={eventData.eventSocialMedia.instagram || ''}
+            onChange={(e) => handleSocialMediaChange('instagram', e.target.value)}
+            error={!!errors.eventSocialMedia?.instagram}
+            helperText={errors.eventSocialMedia?.instagram}
+          />
+          <TextField
+            id="hashtag"
+            label="Hashtag"
+            variant="outlined"
+            name="hashtag"
+            value={eventData.eventSocialMedia.hashtag || ''}
+            onChange={(e) => handleSocialMediaChange('hashtag', e.target.value)}
+            error={!!errors.eventSocialMedia?.hashtag}
+            helperText={errors.eventSocialMedia?.hashtag}
+          />
+          <TextField
+            id="event-privacy"
+            label="Event Privacy"
+            variant="outlined"
+            name="eventPrivacy"
+            value={eventData.eventPrivacy}
+            onChange={handleInputChange}
+            error={!!errors.eventPrivacy}
+            helperText={errors.eventPrivacy}
+          />
+          <TextField
+            id="event-accessibility"
+            label="Event Accessibility"
+            variant="outlined"
+            name="eventAccessibility"
+            value={eventData.eventAccessibility}
+            onChange={handleInputChange}
+            error={!!errors.eventAccessibility}
+            helperText={errors.eventAccessibility}
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
             <Button type="submit" variant="contained" color="primary">
-                Create Event
+              Create Event
             </Button>
-            
             <div className="error-messages">
               {Object.entries(errors).map(([key, value]) => {
                 if (typeof value === 'object' && value !== null) {
@@ -616,10 +337,10 @@ const CreateEvent: React.FC = () => {
                 }
               })}
             </div>
-            </Box>
-        </Box>
-      {/* </LocalizationProvider> */}
-    </ThemeProvider>
+          </Box>  
+        </Stack> 
+      </Box>  
+   // </LocalizationProvider>  
   );
 };
 

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -11,8 +11,8 @@ import "react-clock/dist/Clock.css";
 //import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 //import TextField, { TextFieldProps } from '@mui/material/TextField';
 // import { format, parse } from 'date-fns';
-import InputField from "@/components/InputFields";
 import { TextField, Box, Button, Typography, Stack }  from '@mui/material';
+import { textFieldStyle } from "@/components/InputFields"
 
 
 const CreateEvent: React.FC = () => {
@@ -50,7 +50,7 @@ const CreateEvent: React.FC = () => {
   return (
    //<LocalizationProvider dateAdapter={AdapterDateFns}>
       <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3 }}>
-        <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', color: 'white', mb: 2 }}>
+        <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', color: 'black', mb: 2 }}>
             Add Event
         </Typography>
         <Stack spacing={2}> 
@@ -63,6 +63,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventTitle}
             helperText={errors.eventTitle}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-description"
@@ -73,6 +75,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventDescription}
             helperText={errors.eventDescription}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-category"
@@ -82,7 +86,9 @@ const CreateEvent: React.FC = () => {
             value={eventData.eventCategory}
             onChange={handleInputChange}
             error={!!errors.eventCategory}
-            helperText={errors.eventCategory} 
+            helperText={errors.eventCategory}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }} 
           />
           <div className="mt-1">
             <label className="block text-sm font-medium text-white-700">
@@ -97,22 +103,27 @@ const CreateEvent: React.FC = () => {
               dropdownMode="select"
               dateFormat={"MM-dd-yyyy"}
               placeholderText="Select Date"
+              className="custom-datepicker"
             />
           </div>
 
-          <InputField
+          <TextField
             label="Start Time"
             type="time"
             name="startTime"
             value={startTime || ""}
             onChange={(time) => handleStartTimeChange(time.target.value)}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }} 
           />
-          <InputField
+          <TextField
             label="End Time"
             type="time"
             name="endTime"
             value={endTime || ""}
             onChange={(time) => handleEndTimeChange(time.target.value)}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }} 
           />
 
           {/* <TimePicker
@@ -153,10 +164,12 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventLocation}
             helperText={errors.eventLocation}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <label>
             Event Cover Photo
-          <ImagePicker/>
+          <ImagePicker />
           </label>
           <TextField
             id="event-host"
@@ -167,6 +180,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventHost}
             helperText={errors.eventHost} 
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-website"
@@ -176,7 +191,9 @@ const CreateEvent: React.FC = () => {
             value={eventData.eventWebsite}
             onChange={handleInputChange}
             error={!!errors.eventWebsite}
-            helperText={errors.eventWebsite} 
+            helperText={errors.eventWebsite}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }} 
           />
           <TextField
             id="event-registration"
@@ -187,6 +204,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventRegistration}
             helperText={errors.eventRegistration}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-capacity"
@@ -197,6 +216,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventCapacity}
             helperText={errors.eventCapacity}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-cost"
@@ -207,6 +228,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventCost}
             helperText={errors.eventCost}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-schedule"
@@ -217,6 +240,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventSchedule}
             helperText={errors.eventSchedule}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-speakers"
@@ -227,6 +252,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventSpeakers}
             helperText={errors.eventSpeakers}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-prerequisites"
@@ -236,7 +263,9 @@ const CreateEvent: React.FC = () => {
             value={eventData.eventPrerequisites}
             onChange={handleInputChange}
             error={!!errors.eventPrerequisites}
-            helperText={errors.eventPrerequisites}                 
+            helperText={errors.eventPrerequisites}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}                 
           />
           <TextField
             id="event-cancellation-policy"
@@ -247,6 +276,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventCancellationPolicy}
             helperText={errors.eventCancellationPolicy}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-contact"
@@ -256,7 +287,9 @@ const CreateEvent: React.FC = () => {
             value={eventData.eventContact}
             onChange={handleInputChange}
             error={!!errors.eventContact}
-            helperText={errors.eventContact}         
+            helperText={errors.eventContact}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}         
           />
           <TextField
             id="facebook"
@@ -266,7 +299,9 @@ const CreateEvent: React.FC = () => {
             value={eventData.eventSocialMedia.facebook || ''}
             onChange={(e) => handleSocialMediaChange('facebook', e.target.value)}
             error={!!errors.eventSocialMedia?.facebook}
-            helperText={errors.eventSocialMedia?.facebook}         
+            helperText={errors.eventSocialMedia?.facebook}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}          
           />
           <TextField
             id="twitter"
@@ -277,6 +312,8 @@ const CreateEvent: React.FC = () => {
             onChange={(e) => handleSocialMediaChange('twitter', e.target.value)}
             error={!!errors.eventSocialMedia?.twitter}
             helperText={errors.eventSocialMedia?.twitter}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="instagram"
@@ -287,6 +324,8 @@ const CreateEvent: React.FC = () => {
             onChange={(e) => handleSocialMediaChange('instagram', e.target.value)}
             error={!!errors.eventSocialMedia?.instagram}
             helperText={errors.eventSocialMedia?.instagram}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="hashtag"
@@ -297,6 +336,8 @@ const CreateEvent: React.FC = () => {
             onChange={(e) => handleSocialMediaChange('hashtag', e.target.value)}
             error={!!errors.eventSocialMedia?.hashtag}
             helperText={errors.eventSocialMedia?.hashtag}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-privacy"
@@ -307,6 +348,8 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventPrivacy}
             helperText={errors.eventPrivacy}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <TextField
             id="event-accessibility"
@@ -317,9 +360,11 @@ const CreateEvent: React.FC = () => {
             onChange={handleInputChange}
             error={!!errors.eventAccessibility}
             helperText={errors.eventAccessibility}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
           />
           <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-            <Button type="submit" variant="contained" color="primary">
+            <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none" }}>
               Create Event
             </Button>
             <div className="error-messages">

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -2,22 +2,6 @@
 import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({
-  //Customize your theme here 
-  components: {
-    MuiTextField: {
-      styleOverrides: {
-        root: {
-          '& label': { color: 'white' },
-          '& .MuiInputBase-input': { color: 'white' },
-          '& .MuiOutlinedInput-root': {
-            '& fieldset': { borderColor: 'white' },
-            '&:hover fieldset': { borderColor: 'white' },
-            '&.Mui-focused fieldset': { borderColor: 'white' },
-          },
-        },
-      },
-    },
-  },
   
   palette: {
     primary: {
@@ -27,7 +11,7 @@ const theme = createTheme({
       main: '#95ca59',  
     },
     background: {
-      default: '#bec3c8', 
+      default: '#FFFFF', 
       paper: '#dbdfe0', 
     },
     // Add additional theme configurations as needed

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -2,7 +2,23 @@
 import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({
-  // Customize your theme here
+  //Customize your theme here 
+  components: {
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& label': { color: 'white' },
+          '& .MuiInputBase-input': { color: 'white' },
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': { borderColor: 'white' },
+            '&:hover fieldset': { borderColor: 'white' },
+            '&.Mui-focused fieldset': { borderColor: 'white' },
+          },
+        },
+      },
+    },
+  },
+  
   palette: {
     primary: {
       main: '#08469f',

--- a/components/TagSelector.tsx
+++ b/components/TagSelector.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 
 type TagSelectorProps = {
     selectedTags: string[];
@@ -10,15 +12,20 @@ const TagSelector: React.FC<TagSelectorProps> = ({ selectedTags, allTags, onTagC
     return (
         <label>
             Event Tags
-            <ul className="flex space-x-2">
+            <Stack direction="row" spacing={1} className="mt-2">
                 {allTags.map(tag => (
-                    <li className="mt-2" key={tag}>
-                        <button type="button" onClick={() => onTagClick(tag)} className={`px-2 py-1 ${selectedTags.includes(tag) ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}>
-                            {tag}
-                        </button>
-                    </li>
+                    <Button
+                        key={tag}
+                        variant={selectedTags.includes(tag) ? 'contained' : 'outlined'}
+                        color="primary"
+                        onClick={() => onTagClick(tag)}
+                        size="small"
+                        style={{ textTransform: 'none' }}
+                    >
+                        {tag}
+                    </Button>
                 ))}
-            </ul>
+            </Stack>
         </label>
     );
 };


### PR DESCRIPTION
resolves #205 #215 
 
Changes:
- Resolve Input Field Label and Placeholder Text Conflicts
- Update Create Event Button Color
- Refactor TagSelector component
- In addition to the initial user story requirement I have made a significant change to the codebase optimization by using proper MUI components and moving the custom theme to the themes file, refactoring the TagSelector, and removing redundant styling implementations. 

Suggestions:
- This page still needs some improvement - the time and date picker is implemented using react libraries, perhaps we can use MUI for consistency.
- The sample events in the input fields are created using auto-filling text. I think using a placeholder would be generally more user-friendly for creating new events to guide users without the risk of unintentional submission of the default data. 

![Screenshot 2024-02-27 at 8 52 29 PM](https://github.com/SeattleColleges/nsc-events-nextjs/assets/55855783/f4a9c887-0a53-4117-9315-b3645de2b844)
![Screenshot 2024-02-27 at 8 58 20 PM](https://github.com/SeattleColleges/nsc-events-nextjs/assets/55855783/7e99bcb2-7ae4-4999-82f4-23a048f85961)



