### PR TITLE
nsc-events-nextjs_3_212_add-pronouns-field

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -28,8 +28,6 @@ interface State extends SnackbarOrigin {
 
 const SignUp = () => {
 
-  const router = useRouter();
-
   // Set initial state for password visibility
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -102,13 +100,12 @@ const SignUp = () => {
     let response = await signUp(payload);
     if (response.status === "success") {
       setSnackBarMessage(response.message);
-      router.push("/auth/sign-in");
       if (response.token) {
         localStorage.setItem("token", response.token);
       }
       setTimeout(() => {
         // TODO use router to navigate to home page
-        //window.location.href = "/";
+        window.location.href = "/";
       }, 2000);
     } else {
       setSnackBarMessage(response.message);

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -20,7 +20,6 @@ import { validateSignUp } from "./validateSignUp";
 import NorthSeattleLogo from "../../NorthSeattleLogo.png";
 import React from "react";
 import { signUp } from "./signupApi";
-import { useRouter } from "next/navigation";
 
 interface State extends SnackbarOrigin {
   open: boolean;
@@ -44,6 +43,7 @@ const SignUp = () => {
   const [userInfo, setUserInfo] = useState({
     firstName: "",
     lastName: "",
+    pronouns: "",
     email: "",
     password: "",
     confirmPassword: "",
@@ -53,6 +53,7 @@ const SignUp = () => {
   const [errors, setErrors] = useState<Partial<typeof userInfo>>({
     firstName: "",
     lastName: "",
+    pronouns: "",
     email: "",
     password: "",
     confirmPassword: "",
@@ -67,7 +68,7 @@ const SignUp = () => {
   });
   const { vertical, horizontal, open } = state;
 
-  const { firstName, lastName, email, password, confirmPassword } = userInfo;
+  const { firstName, lastName, pronouns, email, password, confirmPassword } = userInfo;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
     const { name, value } = target;
@@ -91,6 +92,7 @@ const SignUp = () => {
     const payload = {
       firstName,
       lastName,
+      pronouns,
       email,
       password,
       role: "user",
@@ -168,6 +170,18 @@ const SignUp = () => {
             onChange={handleChange}
             error={Boolean(errors.lastName)}
             helperText={errors.lastName}
+            InputProps={{ style: textFieldStyle.input }}
+            InputLabelProps={{ style: textFieldStyle.label }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Pronouns"
+            name="pronouns"
+            value={pronouns}
+            onChange={handleChange}
+            error={Boolean(errors.pronouns)}
+            helperText={errors.pronouns}
             InputProps={{ style: textFieldStyle.input }}
             InputLabelProps={{ style: textFieldStyle.label }}
           />


### PR DESCRIPTION
Resolves #212 

In this PR, I created a field for the user to enter their pronouns when signing up. 

This PR also reverts the changes made to route the user to the login page after signing up (no longer necessary as user is already signed in) from this [PR](https://github.com/SeattleColleges/nsc-events-nextjs/pull/211)

<img width="491" alt="Screenshot 2024-02-27 000749" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/87c37d1b-0926-476b-a6b4-23aa8e010a44">

Dependent on this [PR](https://github.com/SeattleColleges/nsc-events-nestjs/pull/86) 

Related to User Story #209 