### PR TITLE
nsc-events-nextjs_4_232_update-url

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation";
 import Image from "next/image";
 import logo from "../../logo.png";
 import { Container, Paper, Box, TextField, Button, Typography, Link as MuiLink } from "@mui/material";
-import { textFieldStyle } from "@/components/InputFields"
+import { textFieldStyle } from "@/components/InputFields";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 
 // similar to sign-up page, but we're only handling email and password 
 const Signin = () => {
+  
   const [error, setError] = useState("");
   const [userInfo, setUserInfo] = useState({
     email: "",
@@ -29,7 +31,7 @@ const Signin = () => {
     e.preventDefault();
 
     // Fetch sign in
-    const res = await fetch("http://localhost:3000/api/auth/login", {
+    const res = await fetch(`${URL}/auth/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/app/auth/sign-up/signupApi.tsx
+++ b/app/auth/sign-up/signupApi.tsx
@@ -1,4 +1,4 @@
-const URL = "http://localhost:3000/api/auth/signup";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL + "/auth/signup" || "http://localhost:3000/api/auth/signup";
 interface SignUpPayload {
   firstName: string;
   lastName: string;

--- a/components/EventGetter.tsx
+++ b/components/EventGetter.tsx
@@ -5,9 +5,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardMedia, Typography, Grid, Box, CardActions, Button } from '@mui/material';
 import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 
 const getEvents = async() => {
-    const response = await fetch("http://localhost:3000/api/events");
+    const response = await fetch(`${URL}/events`);
     return response.json();
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  env: {
+    // TODO: PULL THIS FROM GITHUB ACTIONS
+    // NSC_EVENTS_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+    NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
In this PR I have refactored the URL for the backend location out of their particular pages and instead moved it into the next.config file as is common practice. I also updated the URL to reflect that it's pointing to https rather than http for additional security. 
**Of note:** in the future we should instead use Environmental variables within github to store the location and then pass that into the next.config file at built time, however this would require a github deploy action yaml file which we don't have for this repo yet.

Testing that the address works:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/35015441/e0e706de-e6d0-40c7-96e0-2fe28cb2df75)


Testing login page:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/35015441/6e528efc-5fb2-4c4c-8253-331cfce1920c)
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/35015441/7ad6103c-0e3d-475d-8b89-4016c9fe011b)
Events displaying:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/35015441/a0264a42-2bfb-4608-9804-97a5745c685d)


This closes #232 
