### PR TITLE
nsc-events-nextjs-4-245-sort-events-by-date

### DIFF
--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -16,7 +16,10 @@ export function HomeEventsList(){
 
     const { data, isLoading, isError } = useQuery<ActivityDatabase[]>({
         queryKey: ["event"],
-        queryFn: getEvents
+        queryFn: getEvents,
+        select: (data) => data.sort((event1, event2) => {
+            return new Date(event1.eventDate).getTime() - new Date(event2.eventDate).getTime();
+          }),
     });
 
     if(isLoading) {


### PR DESCRIPTION
Resolves #245 

This PR accomplishes sorting the events in the event section on the home page by next upcoming date in ascending order (nearest to furthest date).

To test:
- Run the backend w/ your MongoDB database of choice.
- Run the frontend and ensure that there are events displayed.
- Open up MongoDB and edit the date of one of the events to be earlier than the other event dates.
- Refresh the home page and you should see the event that you changed to an earlier date at the top of the list of upcoming events.


https://github.com/SeattleColleges/nsc-events-nextjs/assets/94101953/3bfc378c-9442-4f39-92b7-407c284e2bf7

