### PR TITLE
nsc_events_nextjs_1_250_admin_route_view_all_events_to_home_page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,7 +11,7 @@ const Admin = () => {
           <button className={styles.button}>Edit User Role</button>
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
           <button className={styles.button}>View My Events</button>
-          <button className={styles.button}>View All Events</button>
+          <button className={styles.button}><Link href="/">View All Events</Link></button>
       </div>
   );
 };


### PR DESCRIPTION
Resolves #250
- [x] Admin Page: Route the "View All Events" button to the Home page

This PR routes the View All Events button on the admin page to the home page 

https://github.com/SeattleColleges/nsc-events-nextjs/assets/80575182/ef543457-90a1-43d8-8b6e-c63348414780

because I am having trouble connecting to the DB I cannot test this from an admin profile, just manipulate the urls. I believe this is what we want though.
( please tell me if im doing this right ;-; )