### PR TITLE
nsc_events_nextjs_1_250_creator_route_view_all_events_to_home_page

### DIFF
--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -10,7 +10,7 @@ const Creator = () => {
           <p>FIX: allow only users with creator role to be routed to this page</p> */}
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
           <button className={styles.button}>View My Events</button>
-          <button className={styles.button}>View All Events</button>
+          <button className={styles.button}><Link href="/">View All Events</Link></button>
       </div>
   );
 };


### PR DESCRIPTION

Resolves issue #250 
- [x] Admin Page: Route the "View All Events" button to the Home page

https://github.com/SeattleColleges/nsc-events-nextjs/assets/80575182/39299538-1c13-46f8-8598-595083f51b82


This PR routes the View All Events button on the creator page to the home page 
