### PR TITLE
nsc-events_1_267_route_user_to_home_after_sign_in

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -53,7 +53,7 @@ const Signin = () => {
     } else if (userRole === "creator") {
       router.push("/creator");
     } else {
-      router.push("/profile");
+      router.push("/profile"); //I think this is what I am changing
     }
   };
 


### PR DESCRIPTION
Resolves #267

After signing in, the user should be sent to the home page. As of right now it looks like the user is sent to the profile page.

![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/80575182/f057ae1c-72fa-4326-973a-3b748b3209d7)

I believe I will be changing this to "/"

I would like to wait until mongodb is set up so I can switch between users and see functionality.