### PR TITLE
nsc-events-nextjs-5-258_app_crashes_when_refreshing_event_detail_page

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -34,7 +34,6 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const  [snackbarMessage, setSnackbarMessage] = useState("")
   const queryClient = useQueryClient();
 
-console.log(searchParams)
   const DeleteDialog = () => {
 
     return (

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -124,7 +124,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
           const userRole = JSON.parse(atob(token.split(".")[1])).role
           setAuthed(userRole === "creator" || userRole === "admin")
         }
-      }, []
+      }, [queryClient, searchParams.id]
   )
   return (
       <>

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -34,7 +34,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const  [snackbarMessage, setSnackbarMessage] = useState("")
   const queryClient = useQueryClient();
 
-
+console.log(searchParams)
   const DeleteDialog = () => {
 
     return (
@@ -102,14 +102,21 @@ const EventDetail = ({ searchParams }: SearchParams) => {
     }
   })
 
-  useEffect( () => {
-    const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
-    if(searchParams.id && events != undefined) {
-      const selectedEvent = events
-          .find(event => event._id === searchParams.id) as ActivityDatabase;
-      setEvent(selectedEvent)
-    }
-
+  useEffect(() => {
+      const getEvents = async () => {
+          const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
+          if (events !== undefined) {
+              const selectedEvent = events
+                  .find(event => event._id === searchParams.id) as ActivityDatabase;
+              setEvent(selectedEvent)
+          }
+          else if (searchParams.id) {
+              const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
+              if (response.ok)
+                  await response.json().then(evt => setEvent(evt));
+          }
+      }
+      getEvents()
     const token = localStorage.getItem("token");
     // Sets token state that is used by delete mutation outside of effect
     setToken(token ?? "");
@@ -118,8 +125,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
           const userRole = JSON.parse(atob(token.split(".")[1])).role
           setAuthed(userRole === "creator" || userRole === "admin")
         }
-      }, [queryClient, searchParams.id]
-
+      }, []
   )
   return (
       <>
@@ -182,7 +188,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
 </>
   );
-  
+
 };
 
 export default EventDetail;

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -103,8 +103,9 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   })
 
   useEffect( () => {
-    if(searchParams.id) {
-      const selectedEvent = (queryClient.getQueryData<ActivityDatabase[]>(['event']) as ActivityDatabase[])
+    const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
+    if(searchParams.id && events != undefined) {
+      const selectedEvent = events
           .find(event => event._id === searchParams.id) as ActivityDatabase;
       setEvent(selectedEvent)
     }

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -111,8 +111,9 @@ const EventDetail = ({ searchParams }: SearchParams) => {
           }
           else if (searchParams.id) {
               const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
-              if (response.ok)
+              if (response.ok) {
                   await response.json().then(evt => setEvent(evt));
+              }
           }
       }
       getEvents()


### PR DESCRIPTION
Resolves #258 

Description:
This fix will ensure that the data retrieved from the 'event' query is valid before performing find() on it.

Before fix:
https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/fb1dd9a3-717d-4d1c-9b27-66d067aee7c0

After fix:
https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/e4e46cb0-f528-4eb8-be40-69c4143b3d72

