### PR TITLE
nsc-events-nextjs-5-264-view-my-events-page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -10,7 +10,7 @@ const Admin = () => {
           <p>FIX: allow only users with admin role to be routed to this page</p> */}
           <button className={styles.button}>Edit User Role</button>
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
-          <button className={styles.button}>View My Events</button>
+          <button className={styles.button}><Link href="/my-events">View My Events</Link></button>
           <button className={styles.button}><Link href="/">View All Events</Link></button>
       </div>
   );

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -9,7 +9,7 @@ const Creator = () => {
           <p>FIX: move to pages or use getSession from nextauth</p>
           <p>FIX: allow only users with creator role to be routed to this page</p> */}
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
-          <button className={styles.button}>View My Events</button>
+          <button className={styles.button}><Link href="/my-events">View My Events</Link></button>
           <button className={styles.button}><Link href="/">View All Events</Link></button>
       </div>
   );

--- a/app/my-events/page.tsx
+++ b/app/my-events/page.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import useAuth from "@/hooks/useAuth";
+import styles from "../home.module.css"
+import MyEventsList from "@/components/ViewMyEventsGetter";
+
+// Page to view logged-in user's created events (Admin/Creator ONLY)
+const MyEvents = () => {
+    const { isAuth, user } = useAuth()
+    // check if user is authorized to access page
+    if (isAuth && (user?.role == 'admin' || user?.role == 'creator')){
+        return(
+            <div className={styles.welcomeContainer}>
+                <div className={styles.title}>
+                    <h1>My Created Events</h1> 
+                </div>  
+                <div className={styles.eventContainer}>
+                    <div className={styles.homeEventsList}>
+                        <MyEventsList /> 
+                    </div>
+                </div>
+            </div>   
+        );
+    }
+};
+
+export default MyEvents

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { ActivityDatabase } from "@/models/activityDatabase";
-import { Box, Card, CardContent, Grid, Link, Typography } from "@mui/material";
+import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 // decode the userId from localStorage
 const getUserId = () => {
@@ -45,6 +46,14 @@ export function MyEventsList() {
         <Grid container spacing={1}>
                 {events?.map((event: ActivityDatabase) => (
                     <Grid item xs={12} key={event._id}>
+                        <Link href={
+                            {
+                                pathname: "/event-detail",
+                                query: {
+                                    id: event._id,
+                                },
+                            }
+                        } >
                             <Box sx={{ width: 700, height: 130 }}>
                                 <Card sx={{ display: 'flex', flexDirection: 'column' }}>
                                     <CardContent sx={{ flexGrow: 1 }}>
@@ -57,6 +66,7 @@ export function MyEventsList() {
                                     </CardContent>
                                 </Card>
                             </Box>
+                        </Link>
                     </Grid>
                 ))}
             </Grid>

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { ActivityDatabase } from "@/models/activityDatabase";
+import { Box, Card, CardContent, Grid, Link, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+// decode the userId from localStorage
+const getUserId = () => {
+    const token = localStorage.getItem('token');
+    if (token !== null){
+        const userId = JSON.parse(atob(token.split(".")[1])).id;
+        return userId;
+    }
+    return null;
+}
+// fetch API endpoint that contains the user's created events
+const getMyEvents = async(userId: string) => {
+    const response = await fetch(`http://localhost:3000/api/events/user/${userId}`);
+    return response.json();
+}
+
+export function MyEventsList() {
+    // useState to hold the events from the API call
+    const [events, setEvents] = useState<ActivityDatabase[]>([]);
+    
+    useEffect(() => {
+        const fetchEvents = async () => {
+            try {
+                // decode and grab the logged-in userId from localStorage
+                const userId = getUserId() 
+                if (userId){
+                    // pull user's events from endpoint 
+                    const myEvents = await getMyEvents(userId); 
+                    // set them to the useState hook
+                    setEvents(myEvents)
+                }
+            } catch (error) {
+                console.error("Error fetching user's events:", error);
+            }
+        };
+        fetchEvents();
+    }, []);
+
+    return (
+        <Grid container spacing={1}>
+                {events?.map((event: ActivityDatabase) => (
+                    <Grid item xs={12} key={event._id}>
+                            <Box sx={{ width: 700, height: 130 }}>
+                                <Card sx={{ display: 'flex', flexDirection: 'column' }}>
+                                    <CardContent sx={{ flexGrow: 1 }}>
+                                        <Typography variant="h5" align="left" fontWeight={"bold"}>
+                                            {event.eventTitle}
+                                        </Typography>
+                                        <Typography variant="body2" align="right" color="text.secondary">
+                                            Date: {event.eventDate}
+                                        </Typography>
+                                    </CardContent>
+                                </Card>
+                            </Box>
+                    </Grid>
+                ))}
+            </Grid>
+    );
+}
+
+export default MyEventsList;


### PR DESCRIPTION
Resolves #264

This PR creates a "View My Events" page for Admins/Creators to view the events of the currently logged-in user. I also added a redirection to that page from the 'View My Events" button on the admin/creator dashboard.

### Testing Instructions:
1. Have your backend properly set up. 
- Make sure to comment out `NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api"`, on line 6 of the `next.config.js` file. Otherwise you will be making requests to the production database and it won't let you into your personal DB!
2. Make sure your nsc-events-nestjs backend is on the correct branch!
- Until [#107](https://github.com/SeattleColleges/nsc-events-nestjs/pull/107) is merged, you will need to use `git checkout feature-106-user-events-API-endpoint-01`
3. Create two admin/creator accounts if you haven't and make sure each one has created one or two test events.

4. Once everything is set up, head over to the dashboard on each account and click "View My Events" to see the events you created on the currently logged-in account.

https://github.com/SeattleColleges/nsc-events-nextjs/assets/33855430/ad05874e-2ad5-4e6f-bcfb-18c03d4281b2


