### PR TITLE
nsc-events-nextjs_6_297_archived-events-placeholder-page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,6 +11,7 @@ const Admin = () => {
           <button className={styles.button}>Edit User Role</button>
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
           <button className={styles.button}><Link href="/my-events">View My Events</Link></button>
+          <button className={styles.button}><Link href="/archived-events">View Archived Events</Link></button>
           <button className={styles.button}><Link href="/">View All Events</Link></button>
       </div>
   );

--- a/app/archived-events/page.tsx
+++ b/app/archived-events/page.tsx
@@ -1,0 +1,11 @@
+
+const ArchivedEvents = () => {
+  // Temporary boilerplate code to make it compile
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1>Archived Events</h1>
+    </div>
+  );
+};
+
+export default ArchivedEvents;

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -10,6 +10,7 @@ const Creator = () => {
           <p>FIX: allow only users with creator role to be routed to this page</p> */}
           <button className={styles.button}><Link href="/create-event">Create Event</Link></button>
           <button className={styles.button}><Link href="/my-events">View My Events</Link></button>
+          <button className={styles.button}><Link href="/archived-events">View Archived Events</Link></button>
           <button className={styles.button}><Link href="/">View All Events</Link></button>
       </div>
   );


### PR DESCRIPTION
Resolves #297

I created a placeholder Archived Events page. This page can be reached through the "View Archived Events" button on the admin and creator pages.

![Screenshot 2024-04-28 172508](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/efa185a5-b32e-40fb-a3e4-6faa4cb926db)

Creator View
![Screenshot 2024-04-28 175529](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/f4acb4fc-d67d-4d74-bfde-93919a2a2088)

Admin View
![Screenshot 2024-04-28 175551](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/ca675fa5-f385-49fd-af2b-c9408aab9eda)

Relates to #296
