### PR TITLE
nsc-events-nextjs-6-288-home-page-events-pagination

### DIFF
--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -31,8 +31,9 @@ export function HomeEventsList(){
     useEffect(() => {
         const eventData = getNumEvents(numEvents);
         eventData.then(events => {
-            const newEvents = events.filter((event: { isArchived: boolean; isHidden: boolean; }) => !(event.isArchived || event.isHidden))
-            setEvents(newEvents)
+            // Filter out events where either isArchived or isHidden is true.
+            const activeEvents = events.filter((event: { isArchived: boolean; isHidden: boolean; }) => !(event.isArchived || event.isHidden))
+            setEvents(activeEvents)
             setReachedMaxEvents(events.length < numEvents);
         });
     }, [numEvents]);

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React from "react";
+import React, {useState} from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Card, CardContent, Typography, Grid, Box } from '@mui/material';
+import {Card, CardContent, Typography, Grid, Box, Button} from '@mui/material';
 import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
 
@@ -25,7 +25,9 @@ export function useFilteredEvents() {
 export function HomeEventsList(){
 
     const { data, isLoading, isError } = useFilteredEvents();
-
+    const handleLoadMoreEvents = () => {
+        
+    }
     if(isLoading) {
         return <span>Loading events...</span>
     } else if (isError) {
@@ -59,6 +61,9 @@ export function HomeEventsList(){
                         </Link>
                     </Grid>
                 ))}
+                <Button onClick={handleLoadMoreEvents} variant="contained" color="primary" style={{ textTransform: "none" }}>
+                    Load more events
+                </Button>
             </Grid>
         );
     }

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -7,27 +7,14 @@ import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import EventCard from "./EventCard";
 
-const getEvents = async() => {
-    const response = await fetch("http://localhost:3000/api/events");
-    return response.json();
-}
-
-export function useFilteredEvents() {
-    return useQuery({
-        queryKey: ["event"],
-        queryFn: getEvents,
-        select: (data: ActivityDatabase[]) => data.filter( event =>
-            !(event.isHidden) && !(event.isArchived))?.sort((event1, event2) => {
-            return new Date(event1.eventDate).getTime() - new Date(event2.eventDate).getTime();
-        }),
-    });
-}
-
 export function HomeEventsList(){
     const [numEvents, setNumEvents] = useState(5);
     const [events, setEvents] = useState<ActivityDatabase[] | undefined>([]);
     const [reachedMaxEvents, setReachedMaxEvents] = useState(false)
-    const { isLoading, isError } = useFilteredEvents();
+    const getNumEvents = async(numEvents: number) => {
+        const response = await fetch(`http://localhost:3000/api/events?numEvents=${numEvents}`);
+        return response.json();
+    }
     useEffect(() => {
         const eventData = getNumEvents(numEvents);
         eventData.then(events => {
@@ -37,43 +24,40 @@ export function HomeEventsList(){
             setReachedMaxEvents(events.length < numEvents);
         });
     }, [numEvents]);
-    const getNumEvents = async(numEvents: number) => {
-        const response = await fetch(`http://localhost:3000/api/events/${numEvents}`);
-        return response.json();
-    }
     const handleLoadMoreEvents = () => {
         setNumEvents(num => num + 5);
     };
-    if(isLoading) {
-        return <span>Loading events...</span>
-    } else if (isError) {
-        return <span>Error when fetching events...</span>
-    } else {
-        return (
-            <Grid container spacing={1}>
-                {events?.map((event: ActivityDatabase) => (
-                    <EventCard 
+    // if(isLoading) {
+    //     return <span>Loading events...</span>
+    // } else if (isError) {
+    //     return <span>Error when fetching events...</span>
+    // } else {
+    return (
+        <Grid container spacing={1}>
+            {
+                events?.map((event: ActivityDatabase) => (
+                    <EventCard
                         key={event._id}
-                        event={event} 
+                        event={event}
                     />
 
                 ))}
-                {
-                    !reachedMaxEvents &&
-                    <Button onClick={handleLoadMoreEvents}
-                            type='button'
-                            variant="contained"
-                            color="primary"
-                            style={{
-                                textTransform: "none",
-                                margin: '1em auto',
-                            }}>
-                        Load more events
-                    </Button>
-                }
-            </Grid>
-        );
-    }
+            {
+                !reachedMaxEvents &&
+                <Button onClick={handleLoadMoreEvents}
+                        type='button'
+                        variant="contained"
+                        color="primary"
+                        style={{
+                            textTransform: "none",
+                            margin: '1em auto',
+                        }}>
+                    Load more events
+                </Button>
+            }
+        </Grid>
+    );
+    // }
 }
 
 export default HomeEventsList;

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {Card, CardContent, Typography, Grid, Box, Button} from '@mui/material';
+import { Card, CardContent, Typography, Grid, Box, Button } from '@mui/material';
 import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
 

--- a/components/UpcomingEvent.tsx
+++ b/components/UpcomingEvent.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Card, CardContent, CardMedia, Typography, Grid, Box, CardActions, Button } from '@mui/material';
 import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
-import { useFilteredEvents } from "@/components/HomeEventGetter";
+import { useFilteredEvents } from "@/utility/queries";
 import { formatDate } from "@/utility/dateUtils";
 export function UpcomingEvent(){
 

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -1,0 +1,17 @@
+import {useQuery} from "@tanstack/react-query";
+import {ActivityDatabase} from "@/models/activityDatabase";
+
+const getEvents = async() => {
+    const response = await fetch(`http://localhost:3000/api/events`);
+    return response.json();
+}
+export function useFilteredEvents() {
+    return useQuery<ActivityDatabase[], Error>({
+        queryKey: ["events"],
+        queryFn: getEvents,
+        select: (data: ActivityDatabase[]) => data.filter( event =>
+            !(event.isHidden) && !(event.isArchived))?.sort((event1, event2) => {
+            return new Date(event1.eventDate).getTime() - new Date(event2.eventDate).getTime();
+        }),
+    });
+}


### PR DESCRIPTION
### Note: This branch depends on SeattleColleges/nsc-events-nestjs#110. Until it is merged to main, please make sure to checkout branch `bug-110-remove-duplicate-get-handler` in the nsc-events-nestjs repo before testing this feature.

Resolves #288

A "Load more events" button has been added and on click, 5 new events will be loaded until the end of the events list has been reached. When all of the events have been rendered, the Load More Events button will not be rendered anymore.
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/698421c7-1071-45ea-87c0-1a3b3cd3caea)

Video demonstrating pagination both logged in and logged out:

https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/e7b4f7ff-2cc3-4552-a829-234a81a4a2dc

