### PR TITLE
nsc-events-nextjs-6-287-change-date-format-to-mm-dd-yyyy

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -16,7 +16,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import { useRouter } from "next/navigation";
 import ArchiveDialog from "@/components/ArchiveDialog";
-
+import { formatDate } from "@/utility/dateUtils";
 
 interface SearchParams {
   searchParams: {
@@ -154,7 +154,7 @@ const toggleArchiveDialog = () => {
               {event.eventDescription}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Date: {event.eventDate}
+              Date: {formatDate(event.eventDate)}
             </Typography>
             <Typography variant="body2" color="text.secondary">
               Start Time: {event.eventStartTime}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -2,6 +2,7 @@ import { Box, Card, CardContent, Grid, Typography } from '@mui/material'
 import { ActivityDatabase } from "@/models/activityDatabase";
 import Link from "next/link";
 import React from 'react'
+import { formatDate } from "@/utility/dateUtils";
 
 // declare the event prop that will get passed to the component
 interface EventCardProps {
@@ -9,11 +10,10 @@ interface EventCardProps {
     event: ActivityDatabase; 
   }
 
-function EventCard({ key, event }: EventCardProps) {
-
+function EventCard({ event }: EventCardProps) {
   return (
     <div>
-        <Grid item xs={12} key={key}>
+        <Grid item xs={12} key={event._id}>
             <Link href={
                 {
                     pathname: "/event-detail",
@@ -29,7 +29,7 @@ function EventCard({ key, event }: EventCardProps) {
                                 {event.eventTitle}
                             </Typography>
                             <Typography variant="body2" align="right" color="text.secondary">
-                                Date: {event.eventDate}
+                                Date: { formatDate(event.eventDate) }
                             </Typography>
                         </CardContent>
                     </Card>

--- a/components/UpcomingEvent.tsx
+++ b/components/UpcomingEvent.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardMedia, Typography, Grid, Box, CardActions, Butto
 import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import { useFilteredEvents } from "@/components/HomeEventGetter";
+import { formatDate } from "@/utility/dateUtils";
 export function UpcomingEvent(){
 
     const { data, isLoading, isError } = useFilteredEvents();
@@ -31,7 +32,7 @@ export function UpcomingEvent(){
                                         {event.eventTitle}
                                     </Typography>
                                     <Typography variant="body2" color="text.secondary">
-                                        Date: {event.eventDate}
+                                        Date: {formatDate(event.eventDate)}
                                     </Typography>
                                 </CardContent>
                                 <CardActions >

--- a/utility/dateUtils.ts
+++ b/utility/dateUtils.ts
@@ -1,0 +1,7 @@
+export const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const year = date.getFullYear();
+    return `${month < 10 ? '0' : ''}${month}-${day < 10 ? '0' : ''}${day}-${year}`;
+}


### PR DESCRIPTION
Resolves #287 
This changes the displayed event date format from:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/73eb724c-6022-43fe-b7df-cca584a02e76)
to mm-dd-yyy

Home Page:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/82132167-2e03-4b58-9e37-ae1f5181485a)

Event detail page:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/6327340a-e1a7-4e40-abb2-ae165be877ec)

