### PR TITLE
nsc_events_nextjs_6_309_create_event_page_text_field_width

### DIFF
--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -51,7 +51,7 @@ const CreateEvent: React.FC = () => {
 
   return (
    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3 }}>
+      <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3, width: '75%', mx: 'auto' }}>
         <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', color: 'black', mb: 2 }}>
             Add Event
         </Typography>

--- a/components/TagSelector.tsx
+++ b/components/TagSelector.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 
+
 type TagSelectorProps = {
     selectedTags: string[];
     allTags: string[];
@@ -12,7 +13,7 @@ const TagSelector: React.FC<TagSelectorProps> = ({ selectedTags, allTags, onTagC
     return (
         <label>
             Event Tags
-            <Stack direction="row" spacing={1} className="mt-2">
+            <Stack direction="row" spacing={1} className="mt-2" flexWrap="wrap" useFlexGap>
                 {allTags.map(tag => (
                     <Button
                         key={tag}


### PR DESCRIPTION

Resolves #309 

This pull request will update the create-event page so that the width of the text fields are not too wide (don't fill the entire page). 

I updated the width to only be 75% of the window, and I noticed that the tag selector overflowed off the screen. I also updated the TagSelector component to flex with the window moving the buttons over to the next row. I did this because my next task is to allow the creator to add custom tags, and this update will make that task much easier to accomplish!

Before Update:

https://github.com/SeattleColleges/nsc-events-nextjs/assets/54779894/9119dc7d-4028-4881-8d92-8d2531c54fb0


After I updated the page width:

https://github.com/SeattleColleges/nsc-events-nextjs/assets/54779894/f1bd123d-3f2c-4d18-9e16-29e6d7319663
