### PR TITLE
nsc-events-nextjs-6-337-fix-incorrect-date-format-logic

### DIFF
--- a/utility/dateUtils.ts
+++ b/utility/dateUtils.ts
@@ -1,7 +1,9 @@
 export const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    // 8 hours ahead of Coordinated Universal Time (UTC)
-    date.setUTCHours(8, 0, 0, 0);
+    // PST is 8 hours behind Coordinated Universal Time (UTC).
+    // Therefore, we set hours to 16 since setUTCHours takes
+    // absolute hours values from 0-23.
+    date.setUTCHours(16, 0, 0, 0);
     const options: Intl.DateTimeFormatOptions = {
         timeZone: 'America/Los_Angeles',
         month: '2-digit',

--- a/utility/dateUtils.ts
+++ b/utility/dateUtils.ts
@@ -1,7 +1,7 @@
 export const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
-    const year = date.getFullYear();
-    return `${month < 10 ? '0' : ''}${month}-${day < 10 ? '0' : ''}${day}-${year}`;
+    // 8 hours ahead of Coordinated Universal Time (UTC)
+    date.setUTCHours(8, 0, 0, 0);
+    const options: Intl.DateTimeFormatOptions = { timeZone: 'America/Los_Angeles', month: '2-digit', day: '2-digit', year: 'numeric' };
+    return date.toLocaleString('en-US', options);
 }

--- a/utility/dateUtils.ts
+++ b/utility/dateUtils.ts
@@ -2,6 +2,11 @@ export const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     // 8 hours ahead of Coordinated Universal Time (UTC)
     date.setUTCHours(8, 0, 0, 0);
-    const options: Intl.DateTimeFormatOptions = { timeZone: 'America/Los_Angeles', month: '2-digit', day: '2-digit', year: 'numeric' };
+    const options: Intl.DateTimeFormatOptions = {
+        timeZone: 'America/Los_Angeles',
+        month: '2-digit',
+        day: '2-digit',
+        year: 'numeric'
+    };
     return date.toLocaleString('en-US', options);
 }


### PR DESCRIPTION
The original mm-dd-yyyy date formatting logic was incorrect and would return the date one day before the input date. I believe this was due to time zone discrepancies. 