### PR TITLE
Create-Event Page Feature: Allow custom event tags to be created

### DIFF
--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -67,6 +67,7 @@ const CreateEvent: React.FC = () => {
       setNewTag(e.target.value);
     };
 
+    
   return (
    <LocalizationProvider dateAdapter={AdapterDateFns}>
       <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3, width: '75%', mx: 'auto' }}>

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -9,6 +9,7 @@ import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { format, parse } from 'date-fns';
 import { Box, Button, Typography, Stack }  from '@mui/material';
 import { textFieldStyle } from "@/components/InputFields"
+import { MouseEvent, ChangeEvent, useState, FormEvent } from "react";
 
 
 const CreateEvent: React.FC = () => {
@@ -47,6 +48,24 @@ const CreateEvent: React.FC = () => {
     const onEndTimeChange = (date: Date | null) => {
       const timeStr = date ? format(date, 'HH:mm') : '';
       handleEndTimeChange(timeStr);
+    };
+
+    // For holding useState of event tags and adding custom tags
+    const [customTags, setCustomTags] = useState<string[]>([]);
+    const [newTag, setNewTag] = useState("");
+
+    const addCustomTag = (e: MouseEvent<HTMLButtonElement>) => {
+      // e.stopPropagation();
+      console.log("addCustomTag Hit")
+      e.preventDefault(); //use this instead of stopPropagation to prevent form from submitting
+      if (newTag && !customTags.includes(newTag)) {
+        setCustomTags([...customTags, newTag]);
+        setNewTag(""); // Clear input after adding
+      }
+    };
+
+    const handleNewTagChange = (e: ChangeEvent<HTMLInputElement>) => {
+      setNewTag(e.target.value);
     };
 
   return (
@@ -200,7 +219,7 @@ const CreateEvent: React.FC = () => {
           <TagSelector
             selectedTags={eventData.eventTags}
             allTags={[
-              "Professional Development",
+              ...["Professional Development",
               "Club",
               "Social",
               "Tech",
@@ -214,29 +233,36 @@ const CreateEvent: React.FC = () => {
               "Pizza",
               "Free Food",
               "LGBTQIA",
+              ],
+              ...customTags
             ]}
             onTagClick={handleTagClick}
           />      
-
-          <Box component="form" >
+          <Box>
             <TextField
               id="add-custom-tag"
               label="Add Tag"
               variant="outlined"
               name="addedTag"
-              // value={}
-              // onChange={}
-              error={!!errors.eventSchedule}
-              helperText={errors.eventSchedule}
+              value={newTag}
+              onChange={handleNewTagChange}
+              // Need to figure out what can go in the following values, I commented out from other text-fields
+              // error={}
+              // helperText={}
               InputProps={{ style: textFieldStyle.input }}
               InputLabelProps={{ style: textFieldStyle.label }}
               placeholder="Enter the tag of the event"
             />  
-            <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none", margin: 10 }}>
-              Add Tag
+            <Button 
+              type="button" 
+              variant="contained" 
+              color="primary" 
+              onClick={addCustomTag} 
+              style={{ textTransform: "none", margin: 10 }}
+            >
+                Add Tag
             </Button>
           </Box>
-
           <TextField
             id="event-schedule"
             label="Event Schedule"

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -56,10 +56,10 @@ const CreateEvent: React.FC = () => {
 
     const addCustomTag = (e: MouseEvent<HTMLButtonElement>) => {
       const normalizedNewTag = newTag.toLowerCase();
-      e.preventDefault(); //use this instead of stopPropagation to prevent form from submitting
+      e.preventDefault();
       if (newTag && !customTags.includes(normalizedNewTag)) {
         setCustomTags([...customTags, normalizedNewTag]);
-        setNewTag(""); // Clear input after adding
+        setNewTag(""); 
       }
     };
 
@@ -246,7 +246,8 @@ const CreateEvent: React.FC = () => {
               name="addedTag"
               value={newTag}
               onChange={handleNewTagChange}
-              // Need to figure out what can go in the following values, I commented out from other text-fields
+              // Need to figure out what can go in the following values, 
+              // I commented out from other text-fields
               // error={}
               // helperText={}
               InputProps={{ style: textFieldStyle.input }}

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -55,11 +55,10 @@ const CreateEvent: React.FC = () => {
     const [newTag, setNewTag] = useState("");
 
     const addCustomTag = (e: MouseEvent<HTMLButtonElement>) => {
-      // e.stopPropagation();
-      console.log("addCustomTag Hit")
+      const normalizedNewTag = newTag.toLowerCase();
       e.preventDefault(); //use this instead of stopPropagation to prevent form from submitting
-      if (newTag && !customTags.includes(newTag)) {
-        setCustomTags([...customTags, newTag]);
+      if (newTag && !customTags.includes(normalizedNewTag)) {
+        setCustomTags([...customTags, normalizedNewTag]);
         setNewTag(""); // Clear input after adding
       }
     };

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -33,7 +33,7 @@ const CreateEvent: React.FC = () => {
     // Convert startTime and endTime from string to Date for TimePicker
     const startTimeDate = startTime ? parse(startTime, 'HH:mm', new Date()) : null;
     const endTimeDate = endTime ? parse(endTime, 'HH:mm', new Date()) : null;
-  
+
     const handleDateChange = (newDate: Date | null) => {
       setSelectedDate(newDate);
     };
@@ -216,7 +216,27 @@ const CreateEvent: React.FC = () => {
               "LGBTQIA",
             ]}
             onTagClick={handleTagClick}
-          />        
+          />      
+
+          <Box component="form" >
+            <TextField
+              id="add-custom-tag"
+              label="Add Tag"
+              variant="outlined"
+              name="addedTag"
+              // value={}
+              // onChange={}
+              error={!!errors.eventSchedule}
+              helperText={errors.eventSchedule}
+              InputProps={{ style: textFieldStyle.input }}
+              InputLabelProps={{ style: textFieldStyle.label }}
+              placeholder="Enter the tag of the event"
+            />  
+            <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none", margin: 10 }}>
+              Add Tag
+            </Button>
+          </Box>
+
           <TextField
             id="event-schedule"
             label="Event Schedule"

--- a/components/TagSelector.tsx
+++ b/components/TagSelector.tsx
@@ -21,7 +21,7 @@ const TagSelector: React.FC<TagSelectorProps> = ({ selectedTags, allTags, onTagC
                         color="primary"
                         onClick={() => onTagClick(tag)}
                         size="small"
-                        style={{ textTransform: 'none' }}
+                        style={{ textTransform: 'capitalize' }}
                     >
                         {tag}
                     </Button>


### PR DESCRIPTION
Reference #291 

https://github.com/SeattleColleges/nsc-events-nextjs/assets/54779894/93a7a96a-6efa-4adb-afd4-d4fafe048b1a

Update the event tags section so that creators can make their own custom tags and it will add on to the list of tags. 


I did notice (reference near the end of the video) that if you could around the tag tiles, the first tag is clicked, and I could not figure out the solution if someone has any suggestions! (This was still an issue before I made the changes) 

https://github.com/SeattleColleges/nsc-events-nextjs/assets/54779894/a0b8d5bb-e644-4e47-92e9-035500758c77
