### PR TITLE
nsc-events-nextjs_7_359_edit-messages-redirect

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect, useState } from 'react';
-import { Typography, Card, CardContent, CardMedia, Box, Button } from '@mui/material';
+import { Typography, Card, CardContent, CardMedia, Box, Button, SnackbarContent } from '@mui/material';
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { activityDatabase, ActivityDatabase } from "@/models/activityDatabase";
 import Snackbar from "@mui/material/Snackbar";
@@ -208,9 +208,13 @@ const toggleArchiveDialog = () => {
               setSnackbarMessage("")
             }}
             autoHideDuration={1200}
-            anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-            message={snackbarMessage}
-        />
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        >
+            <SnackbarContent
+              message={snackbarMessage}
+              sx={{color: 'black'}}
+            />
+        </Snackbar>
 
 </Box>
 

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -212,7 +212,7 @@ const toggleArchiveDialog = () => {
         >
             <SnackbarContent
               message={snackbarMessage}
-              sx={{color: 'black'}}
+              sx={{ color: 'black' }}
             />
         </Snackbar>
 

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -3,7 +3,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
-import { Button } from "@mui/material";
+import { Button, SnackbarContent } from "@mui/material";
 import React, { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -84,9 +84,13 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
                     setSnackbarMessage("")
                 }}
                 autoHideDuration={1200}
-                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                message={snackbarMessage}
-            />
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            >
+                <SnackbarContent
+                    message={snackbarMessage}
+                    sx={{color: 'black'}}
+                />
+            </Snackbar>
         </>
     )
 }

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -88,7 +88,7 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
             >
                 <SnackbarContent
                     message={snackbarMessage}
-                    sx={{color: 'black'}}
+                    sx={{ color: 'black' }}
                 />
             </Snackbar>
         </>

--- a/components/AttendDialog.tsx
+++ b/components/AttendDialog.tsx
@@ -1,7 +1,7 @@
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
-import { Box, Button, Checkbox, DialogContentText, Divider, FormControlLabel, Tooltip, Typography } from "@mui/material";
+import { Box, Button, Checkbox, DialogContentText, Divider, FormControlLabel, SnackbarContent, Tooltip, Typography } from "@mui/material";
 import DialogActions from "@mui/material/DialogActions";
 import Snackbar from "@mui/material/Snackbar";
 import IconButton from "@mui/material/IconButton";
@@ -63,10 +63,6 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
         mutationFn: attendEvent,
         onSuccess: () => {
             setSnackbarMessage("Successfully added your attendance.");
-            setTimeout( () => {
-                router.push("/");
-            }, 1200)
-
         },
         onError: (error: String) => {
             setSnackbarMessage("Failed to attend event.");
@@ -132,9 +128,13 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
                     setSnackbarMessage("")
                 }}
                 autoHideDuration={1200}
-                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                message={snackbarMessage}
-            />
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            >
+                <SnackbarContent
+                    message={snackbarMessage}
+                    sx={{color: 'black'}}
+                />
+            </Snackbar>
         </>
     )
 }

--- a/components/AttendDialog.tsx
+++ b/components/AttendDialog.tsx
@@ -132,7 +132,7 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
             >
                 <SnackbarContent
                     message={snackbarMessage}
-                    sx={{color: 'black'}}
+                    sx={{ color: 'black' }}
                 />
             </Snackbar>
         </>


### PR DESCRIPTION
Resolves #359

This PR makes it so that successfully attending the event does not redirect the user. All Snackbar messages have been made horizontally center, with black text.


https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/0e735bdf-4a4c-4b48-8db8-3cb1aed9b871

![Screenshot 2024-05-21 204050](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/763256e1-eb70-4733-8f59-6d290541012d)
![Screenshot 2024-05-21 204200](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/b86c2ddb-4739-4196-8b9e-66ffaa8f9326)


Related to #358