### PR TITLE
nsc-events-nextjs_7_360_creator-access

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -30,13 +30,14 @@ interface SearchParams {
 const EventDetail = ({ searchParams }: SearchParams) => {
   const router = useRouter();
   const [event, setEvent] = useState(activityDatabase)
-  const [isAuthed, setAuthed] = useState(false);
   const [token, setToken] = useState("")
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState("")
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [attendDialogOpen, setAttendDialogOpen] = useState(false);
+  const [userId, setUserId] = useState("");
+  const [userRole, setUserRole] = useState("");
   const queryClient = useQueryClient();
 
   const DeleteDialog = () => {
@@ -91,9 +92,13 @@ const EventDetail = ({ searchParams }: SearchParams) => {
         }
       });
        console.log(response)
-       return response.json();
+       if (!response.ok) {
+        throw new Error(`Failed to delete event: ${response.statusText}`);
+      }
+      return response.json();
     } catch (error) {
-      console.error('error: ', error)
+      console.error('error: ', error);
+      throw error;
     }
   }
 
@@ -132,10 +137,12 @@ const EventDetail = ({ searchParams }: SearchParams) => {
     setToken(token ?? "");
 
         if(token) {
-          const userRole = JSON.parse(atob(token.split(".")[1])).role
-          setAuthed(userRole === "creator" || userRole === "admin")
+          const role = JSON.parse(atob(token.split(".")[1])).role;
+          const id = JSON.parse(atob(token.split(".")[1])).id;
+          setUserRole(role);
+          setUserId(id);
         }
-      }, [queryClient, searchParams.id]
+      }, [queryClient, searchParams.id, token, userId]
   )
 
   const toggleAttendDialog = () => {
@@ -187,7 +194,7 @@ const toggleArchiveDialog = () => {
         </Card>
           <div style={ { width: '100vh', display: 'flex' }}>
             <div style={ { display: 'flex', width: '100vh', gap: '25px',  justifyContent: 'center', alignItems: 'center', marginLeft: '13vh' } }>
-              {isAuthed && (
+              {(userRole === "admin" || (userRole === "creator" && event?.createdByUser === userId)) && (
                   <>
                     <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }} onClick={ () => { toggleEditDialog() }}> <EditIcon sx={ { marginRight: '5px' }}/> Edit </Button>
                     <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }}   onClick={ () => setDialogOpen(true)} > <DeleteIcon sx={ { marginRight: '5px' }}/> Delete </Button>

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -29,11 +29,16 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
                     'Authorization': `Bearer ${token}`
                 }
             });
-            return response.json();
-        } catch (error) {
-            console.error('error: ', error)
-        }
-    }
+            if (!response.ok) {
+                throw new Error(`Failed to archive event: ${response.statusText}`);
+              }
+              return response.json();
+            } catch (error) {
+              console.error('error: ', error);
+              throw error;
+            }
+          }
+        
 
     const { mutate: archiveEventMutation }  = useMutation({
         mutationFn: archiveEvent,


### PR DESCRIPTION
Resolves #360

This PR makes it so that creators are not able to edit, archive, or delete buttons for events not created by them. The buttons will only be visible if it is their own events.

I also made some small fixes for error handling.

An example of a creator user logged in attempting to delete an event created by another user.

https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/017573e8-ca51-4f0d-8549-505dfa23189b

Related to #358
