### PR TITLE
nsc-events-nextjs_7_295_arrow_icons

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client';
 
 import React, { useEffect, useState } from 'react';
 import { Typography, Card, CardContent, CardMedia, Box, Button } from '@mui/material';
@@ -21,6 +21,9 @@ import EditDialog from "@/components/EditDialog";
 
 import { formatDate } from "@/utility/dateUtils";
 
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+
 interface SearchParams {
   searchParams: {
     id: string;
@@ -29,140 +32,142 @@ interface SearchParams {
 
 const EventDetail = ({ searchParams }: SearchParams) => {
   const router = useRouter();
-  const [event, setEvent] = useState(activityDatabase)
+  const [event, setEvent] = useState<ActivityDatabase>(activityDatabase);
+  const [events, setEvents] = useState<ActivityDatabase[]>([]);
   const [isAuthed, setAuthed] = useState(false);
-  const [token, setToken] = useState("")
+  const [token, setToken] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
-  const [snackbarMessage, setSnackbarMessage] = useState("")
+  const [snackbarMessage, setSnackbarMessage] = useState("");
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [attendDialogOpen, setAttendDialogOpen] = useState(false);
   const queryClient = useQueryClient();
 
-  const DeleteDialog = () => {
-
-    return (
-        <>
-          <Dialog      open={dialogOpen}
-                       onClose={() => {
-                         setDialogOpen(false)
-                       }}
-                       aria-describedby="Dialogue to confirm event deletion">
-
-            <DialogTitle>
-              {"Delete Event?"}
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText id="alert-dialog-description">
-                Are you sure you want to delete this event?
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => {
-                setDialogOpen(false)
-              }}>Cancel</Button>
-              <Button onClick={() => {
-                deleteEventMutation(event._id)
-                setDialogOpen(false);
-              }} autoFocus>
-                Delete
-              </Button>
-            </DialogActions>
-
-          </Dialog>
-        </>
-    )
-
-  }
-
-
+  const DeleteDialog = () => (
+    <Dialog
+      open={dialogOpen}
+      onClose={() => setDialogOpen(false)}
+      aria-describedby="Dialogue to confirm event deletion"
+    >
+      <DialogTitle>{"Delete Event?"}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          Are you sure you want to delete this event?
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+        <Button
+          onClick={() => {
+            deleteEventMutation(event._id);
+            setDialogOpen(false);
+          }}
+          autoFocus
+        >
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
 
   const toggleEditDialog = () => {
     setEditDialogOpen(!editDialogOpen);
-  }
+  };
 
   const deleteEvent = async (id: string) => {
     try {
-       const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
+      const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${token}`
         }
       });
-       console.log(response)
-       return response.json();
+      return response.json();
     } catch (error) {
-      console.error('error: ', error)
+      console.error('error: ', error);
     }
-  }
+  };
 
-  const { mutate: deleteEventMutation }  = useMutation({
+  const { mutate: deleteEventMutation } = useMutation({
     mutationFn: deleteEvent,
-     onSuccess: () => {
+    onSuccess: () => {
       setSnackbarMessage("Successfully deleted event.");
-      setTimeout( () => {
-        router.push("/")
-      }, 1200)
-
-     },
+      setTimeout(() => {
+        router.push("/");
+      }, 1200);
+    },
     onError: () => {
       setSnackbarMessage("Failed to delete event.");
     }
-  })
+  });
 
   useEffect(() => {
-      const getEvents = async () => {
-          const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
-          if (events !== undefined) {
-              const selectedEvent = events
-                  .find(event => event._id === searchParams.id) as ActivityDatabase;
-              setEvent(selectedEvent)
-          }
-          else if (searchParams.id) {
-              const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
-              if (response.ok) {
-                  await response.json().then(evt => setEvent(evt));
-              }
-          }
+    const getEvents = async () => {
+      const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
+      if (events !== undefined) {
+        setEvents(events);
+        const selectedEvent = events.find(event => event._id === searchParams.id) as ActivityDatabase;
+        setEvent(selectedEvent);
+      } else if (searchParams.id) {
+        const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
+        if (response.ok) {
+          const evt = await response.json();
+          setEvent(evt);
+          setEvents([evt]); // assuming there's only one event in response
+        }
       }
-      getEvents()
+    };
+    getEvents();
     const token = localStorage.getItem("token");
-    // Sets token state that is used by delete mutation outside of effect
     setToken(token ?? "");
 
-        if(token) {
-          const userRole = JSON.parse(atob(token.split(".")[1])).role
-          setAuthed(userRole === "creator" || userRole === "admin")
-        }
-      }, [queryClient, searchParams.id]
-  )
+    if (token) {
+      const userRole = JSON.parse(atob(token.split(".")[1])).role;
+      setAuthed(userRole === "creator" || userRole === "admin");
+    }
+  }, [queryClient, searchParams.id]);
 
   const toggleAttendDialog = () => {
-      if(token === '') {
-          console.log(token)
-          router.push("auth/sign-in")
-      } else {
-          setAttendDialogOpen(!attendDialogOpen);
-      }
+    if (token === '') {
+      router.push("auth/sign-in");
+    } else {
+      setAttendDialogOpen(!attendDialogOpen);
+    }
+  };
 
-  }
-  
-const toggleArchiveDialog = () => {
+  const toggleArchiveDialog = () => {
     setArchiveDialogOpen(!archiveDialogOpen);
-  }
+  };
+
+  const getNextEvent = () => {
+    const currentIndex = events.findIndex(e => e._id === event._id);
+    if (currentIndex < events.length - 1) {
+      const nextEvent = events[currentIndex + 1];
+      router.push(`/eventDetails?id=${nextEvent._id}`);
+    }
+  };
+
+  const getPrevEvent = () => {
+    const currentIndex = events.findIndex(e => e._id === event._id);
+    if (currentIndex > 0) {
+      const prevEvent = events[currentIndex - 1];
+      router.push(`/eventDetails?id=${prevEvent._id}`);
+    }
+  };
 
   return (
-      <>
-      <Box className={styles.container}>
-        <Box className={styles.formContainer } sx={{ minHeight: '69vh', maxHeight: '100vh', width: '100vh' , marginTop: '10vh' }}>
-
+    <Box className={styles.container}>
+      <Button onClick={getPrevEvent}>
+        <ArrowBackIosIcon sx={{ color: 'white', fontSize: '100px' }} />
+      </Button>
+      <Box className={styles.formContainer} sx={{ minHeight: '69vh', maxHeight: '100vh', width: '100vh', marginTop: '10vh' }}>
         <Card sx={{ width: '45vh', minHeight: '59vh', maxHeight: '100vh', marginBottom: '5vh' }}>
           <CardMedia
-              component="img"
-              image={event.eventCoverPhoto}
-              alt={event.eventTitle}
-              sx={{ height: '37vh' }}
+            component="img"
+            image={event.eventCoverPhoto}
+            alt={event.eventTitle}
+            sx={{ height: '37vh' }}
           />
           <CardContent>
             <Typography gutterBottom variant="h5" component="div">
@@ -185,38 +190,44 @@ const toggleArchiveDialog = () => {
             </Typography>
           </CardContent>
         </Card>
-          <div style={ { width: '100vh', display: 'flex' }}>
-            <div style={ { display: 'flex', width: '100vh', gap: '25px',  justifyContent: 'center', alignItems: 'center', marginLeft: '13vh' } }>
-              {isAuthed && (
-                  <>
-                    <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }} onClick={ () => { toggleEditDialog() }}> <EditIcon sx={ { marginRight: '5px' }}/> Edit </Button>
-                    <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }}   onClick={ () => setDialogOpen(true)} > <DeleteIcon sx={ { marginRight: '5px' }}/> Delete </Button>
-                    <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }} onClick={ () => toggleArchiveDialog() }> <ArchiveIcon sx={ { marginRight: '5px' }}/> Archive </Button>
-                  </>)
-              }
-            </div>
-            <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px', marginRight: '50px' }} onClick={ () => { toggleAttendDialog()}}> Attend </Button>
+        <div style={{ width: '100vh', display: 'flex' }}>
+          <div style={{ display: 'flex', width: '100vh', gap: '25px', justifyContent: 'center', alignItems: 'center', marginLeft: '13vh' }}>
+            {isAuthed && (
+              <>
+                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={toggleEditDialog}>
+                  <EditIcon sx={{ marginRight: '5px' }} /> Edit
+                </Button>
+                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={() => setDialogOpen(true)}>
+                  <DeleteIcon sx={{ marginRight: '5px' }} /> Delete
+                </Button>
+                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={toggleArchiveDialog}>
+                  <ArchiveIcon sx={{ marginRight: '5px' }} /> Archive
+                </Button>
+              </>
+            )}
           </div>
-        </Box>
-        <DeleteDialog/>
-        <AttendDialog isOpen={attendDialogOpen} eventId={event._id} dialogToggle={toggleAttendDialog}/>
-        <ArchiveDialog isOpen={archiveDialogOpen} eventId={event._id} dialogToggle={toggleArchiveDialog}/>
-        <EditDialog isOpen={ editDialogOpen } event={event} toggleEditDialog={toggleEditDialog}/>
-        <Snackbar
-            open={Boolean(snackbarMessage)}
-            onClose={() => {
-              setSnackbarMessage("")
-            }}
-            autoHideDuration={1200}
-            anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-            message={snackbarMessage}
-        />
+          <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px', marginRight: '50px' }} onClick={toggleAttendDialog}>
+            Attend
+          </Button>
+        </div>
+      </Box>
+      <DeleteDialog />
+      <AttendDialog isOpen={attendDialogOpen} eventId={event._id} dialogToggle={toggleAttendDialog} />
+      <ArchiveDialog isOpen={archiveDialogOpen} eventId={event._id} dialogToggle={toggleArchiveDialog} />
+      <EditDialog isOpen={editDialogOpen} event={event} toggleEditDialog={toggleEditDialog} />
+      <Snackbar
+        open={Boolean(snackbarMessage)}
+        onClose={() => setSnackbarMessage('')}
+        autoHideDuration={1200}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        message={snackbarMessage}
+      />
 
-</Box>
-
-</>
+      <Button onClick={getNextEvent}>
+        <ArrowForwardIosIcon sx={{ color: 'white', fontSize: '100px' }} />
+      </Button>
+    </Box>
   );
-
 };
 
 export default EventDetail;


### PR DESCRIPTION

(Help is needed on this User Story/Work in progress)

Relates to #293 

- [ ] Add arrow icons to the left and right side of the event.

When the right arrow is clicked, the event being displayed switches to the next one. If there are no more events, the right arrow should disappear.

When the left arrow is clicked, the event being displayed switches to the previous one. If there are no more previous events, the left arrow should disappear.

![Image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/36825393/d113fdbd-e2f4-4ec7-9d14-7033824519f6)
