### PR TITLE
NSC_NextJS_Sprint_7_357_Change_Edit_to_Done

### DIFF
--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -108,7 +108,7 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue((event.target as HTMLInputElement).value);
   };
-
+//Edit Here to change
   return (
     <Dialog
       sx={{ "& .MuiDialog-paper": { width: "50%", maxHeight: 435 } }}

--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -17,7 +17,6 @@ import Alert, { AlertColor } from '@mui/material/Alert';
 
 
 const options = ["admin", "creator", "user"];
-
 /**
  * Props for the ConfirmationDialogRaw component.
  */
@@ -26,7 +25,7 @@ interface ConfirmationDialogRawProps {
   keepMounted: boolean;
   value: string;
   open: boolean;
-  onClose: (value?: string) => void;
+  onClose: (value?: string, success?: boolean) => void;
   setSnackbarOpen: (open: boolean) => void;
   setSnackbarMessage: (message: string) => void;
   setSnackbarSeverity: (severity: 'error' | 'warning' | 'info' | 'success') => void;
@@ -38,41 +37,39 @@ interface ConfirmationDialogRawProps {
  * @param props - The component props.
  * @returns The rendered ConfirmationDialogRaw component.
  */
-export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user: UserCardProps } ) {
+export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user: UserCardProps }) {
   const { onClose, value: valueProp, open, user, ...other } = props;
   const [value, setValue] = useState(valueProp);
   const radioGroupRef = useRef<HTMLElement>(null);
-  
+
   useEffect(() => {
     if (!open) {
       setValue(valueProp);
     }
   }, [valueProp, open]);
 
-  /**
-   * Handles the entering event of the dialog.
-   */
+/**
+ * Handles the entering event of the dialog.
+ */
   const handleEntering = () => {
     if (radioGroupRef.current != null) {
       radioGroupRef.current.focus();
     }
-  };
+  }; 
 
   /**
-   * Handles the cancel action.
-   */
+     * Handles the cancel action.
+  */
   const handleCancel = () => {
     onClose();
   };
 
-  /**
+ /**
    * Handles the click event when the user confirms the role update.
    * @returns {void}
    */
   const handleOk = async () => {
     const token = localStorage.getItem('token');
-    console.log('Token:', token);
-    // TODO: Update user role in the database
     try {
       const response = await fetch(`http://localhost:3000/api/users/update/${user.id}`, {
         method: 'PATCH',
@@ -83,7 +80,7 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
         body: JSON.stringify({ role: value })
       });
       if (response.ok) {
-        onClose(value);
+        onClose(value, true); // Indicate success
         props.setSnackbarSeverity('success');
         props.setSnackbarMessage('User role updated successfully!');
         props.setSnackbarOpen(true);
@@ -100,7 +97,6 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
       props.setSnackbarOpen(true);
     }
   };
-
   /**
    * Handles the change event of the input element.
    * @param event - The change event object.
@@ -108,7 +104,7 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue((event.target as HTMLInputElement).value);
   };
-//Edit Here to change
+
   return (
     <Dialog
       sx={{ "& .MuiDialog-paper": { width: "50%", maxHeight: 435 } }}
@@ -155,11 +151,13 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
  * @param {Function} props.onClose - The function to be called when the dialog is closed.
  * @returns {JSX.Element} The rendered EditUserRoleDialog component.
  */
+
 export default function EditUserRoleDialog({
   user,
+  onClose,
 }: {
   user: UserCardProps;
-  onClose: () => void;
+  onClose: (success: boolean) => void;
 }): JSX.Element {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState(user.role);
@@ -167,17 +165,16 @@ export default function EditUserRoleDialog({
   const [snackbarMessage, setSnackbarMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
 
-
   const handleClickListItem = () => {
     setOpen(true);
   };
 
-  const handleClose = (newValue?: string) => {
+  const handleClose = (newValue?: string, success: boolean = false) => {
     setOpen(false);
-
     if (newValue) {
       setValue(newValue);
     }
+    onClose(success);
   };
 
   return (

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -13,14 +13,23 @@ export interface UserCardProps {
 
 function UserCard({ user }: { user: UserCardProps }) {
   const [openDialog, setOpenDialog] = useState(false);
+  const [editCompleted, setEditCompleted] = useState(false);
 
   const handleEditClick = () => {
-    setOpenDialog(true);
+    if (editCompleted) {
+      window.location.reload();
+    } else {
+      setOpenDialog(true);
+    }
   };
 
-  const handleCloseDialog = () => {
+  const handleCloseDialog = (success: boolean) => {
     setOpenDialog(false);
+    if (success) {
+      setEditCompleted(true);
+    }
   };
+
   return (
     <Container
       fixed
@@ -65,11 +74,12 @@ function UserCard({ user }: { user: UserCardProps }) {
             startIcon={<EditIcon />}
             onClick={handleEditClick}
           >
-            Edit
+            {editCompleted ? "Done" : "Edit"}
           </Button>
         </Box>
       </Stack>
     </Container>
   );
 }
+
 export default UserCard;

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   env: {
     // TODO: PULL THIS FROM GITHUB ACTIONS
     // NSC_EVENTS_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-    NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
+    //NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
   },
 }
 


### PR DESCRIPTION
Change the "Edit" button to "Done" when finish selecting role
<img width="151" alt="Screenshot 2024-05-23 at 6 44 26 PM" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/117953848/c7b3b895-4ff6-4529-9c60-f3e285bedeb5">
After the roles have been changed "Edit" button changes to "Don" and the page will refresh after clicking the "Done" button.

https://github.com/SeattleColleges/nsc-events-nextjs/assets/117953848/3c87d84a-3aab-4dc1-858d-30ae9d8e4657

