### PR TITLE
nsc-events-nextjs-07-355-view-more-details-button-user-functionality

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -1,14 +1,22 @@
-"use client"
+"use client";
 
-import React, { useEffect, useState } from 'react';
-import { Typography, Card, CardContent, CardMedia, Box, Button, SnackbarContent } from '@mui/material';
+import React, { useEffect, useState } from "react";
+import {
+  Typography,
+  Card,
+  CardContent,
+  CardMedia,
+  Box,
+  Button,
+  SnackbarContent,
+} from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { activityDatabase, ActivityDatabase } from "@/models/activityDatabase";
 import Snackbar from "@mui/material/Snackbar";
 import styles from "@/app/home.module.css";
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import ArchiveIcon from '@mui/icons-material/Archive';
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import ArchiveIcon from "@mui/icons-material/Archive";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -20,6 +28,7 @@ import ArchiveDialog from "@/components/ArchiveDialog";
 import EditDialog from "@/components/EditDialog";
 
 import { formatDate } from "@/utility/dateUtils";
+import ViewMoreDetailsDialog from "@/components/ViewMoreDetailsDialog";
 
 interface SearchParams {
   searchParams: {
@@ -29,198 +38,274 @@ interface SearchParams {
 
 const EventDetail = ({ searchParams }: SearchParams) => {
   const router = useRouter();
-  const [event, setEvent] = useState(activityDatabase)
+  const [event, setEvent] = useState(activityDatabase);
   const [isAuthed, setAuthed] = useState(false);
-  const [token, setToken] = useState("")
+  const [token, setToken] = useState("");
+  const [userRole, setUserRole] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
-  const [snackbarMessage, setSnackbarMessage] = useState("")
+  const [snackbarMessage, setSnackbarMessage] = useState("");
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [attendDialogOpen, setAttendDialogOpen] = useState(false);
+  const [moreDetailsDialogOpen, setMoreDetailsDialogOpen] = useState(false);
   const queryClient = useQueryClient();
 
   const DeleteDialog = () => {
-
     return (
-        <>
-          <Dialog      open={dialogOpen}
-                       onClose={() => {
-                         setDialogOpen(false)
-                       }}
-                       aria-describedby="Dialogue to confirm event deletion">
-
-            <DialogTitle>
-              {"Delete Event?"}
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText id="alert-dialog-description">
-                Are you sure you want to delete this event?
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => {
-                setDialogOpen(false)
-              }}>Cancel</Button>
-              <Button onClick={() => {
-                deleteEventMutation(event._id)
+      <>
+        <Dialog
+          open={dialogOpen}
+          onClose={() => {
+            setDialogOpen(false);
+          }}
+          aria-describedby="Dialogue to confirm event deletion"
+        >
+          <DialogTitle>{"Delete Event?"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              Are you sure you want to delete this event?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
                 setDialogOpen(false);
-              }} autoFocus>
-                Delete
-              </Button>
-            </DialogActions>
-
-          </Dialog>
-        </>
-    )
-
-  }
-
-
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                deleteEventMutation(event._id);
+                setDialogOpen(false);
+              }}
+              autoFocus
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  };
 
   const toggleEditDialog = () => {
     setEditDialogOpen(!editDialogOpen);
-  }
+  };
 
   const deleteEvent = async (id: string) => {
     try {
-       const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
-        method: 'DELETE',
+      const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
+        method: "DELETE",
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        }
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
       });
-       console.log(response)
-       return response.json();
+      console.log(response);
+      return response.json();
     } catch (error) {
-      console.error('error: ', error)
+      console.error("error: ", error);
     }
-  }
+  };
 
-  const { mutate: deleteEventMutation }  = useMutation({
+  const { mutate: deleteEventMutation } = useMutation({
     mutationFn: deleteEvent,
-     onSuccess: () => {
+    onSuccess: () => {
       setSnackbarMessage("Successfully deleted event.");
-      setTimeout( () => {
-        router.push("/")
-      }, 1200)
-
-     },
+      setTimeout(() => {
+        router.push("/");
+      }, 1200);
+    },
     onError: () => {
       setSnackbarMessage("Failed to delete event.");
-    }
-  })
+    },
+  });
 
   useEffect(() => {
-      const getEvents = async () => {
-          const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
-          if (events !== undefined) {
-              const selectedEvent = events
-                  .find(event => event._id === searchParams.id) as ActivityDatabase;
-              setEvent(selectedEvent)
-          }
-          else if (searchParams.id) {
-              const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
-              if (response.ok) {
-                  await response.json().then(evt => setEvent(evt));
-              }
-          }
+    const getEvents = async () => {
+      const events = queryClient.getQueryData<ActivityDatabase[]>(["event"]);
+      if (events !== undefined) {
+        const selectedEvent = events.find(
+          (event) => event._id === searchParams.id
+        ) as ActivityDatabase;
+        setEvent(selectedEvent);
+      } else if (searchParams.id) {
+        const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
+        if (response.ok) {
+          await response.json().then((evt) => setEvent(evt));
+        }
       }
-      getEvents()
+    };
+    getEvents();
     const token = localStorage.getItem("token");
     // Sets token state that is used by delete mutation outside of effect
     setToken(token ?? "");
 
-        if(token) {
-          const userRole = JSON.parse(atob(token.split(".")[1])).role
-          setAuthed(userRole === "creator" || userRole === "admin")
-        }
-      }, [queryClient, searchParams.id]
-  )
+    if (token) {
+      const role = JSON.parse(atob(token.split(".")[1])).role;
+      setUserRole(role);
+      setAuthed(role === "creator" || role === "admin");
+    }
+  }, [queryClient, searchParams.id]);
 
   const toggleAttendDialog = () => {
-      if(token === '') {
-          console.log(token)
-          router.push("auth/sign-in")
-      } else {
-          setAttendDialogOpen(!attendDialogOpen);
-      }
+    if (token === "") {
+      console.log(token);
+      router.push("auth/sign-in");
+    } else {
+      setAttendDialogOpen(!attendDialogOpen);
+    }
+  };
 
-  }
-  
-const toggleArchiveDialog = () => {
+  const toggleViewMoreDetailsDialog = () => {
+    setMoreDetailsDialogOpen(!moreDetailsDialogOpen);
+  };
+
+  const toggleArchiveDialog = () => {
     setArchiveDialogOpen(!archiveDialogOpen);
-  }
+  };
 
   return (
-      <>
+    <>
       <Box className={styles.container}>
-        <Box className={styles.formContainer } sx={{ minHeight: '69vh', maxHeight: '100vh', width: '100vh' , marginTop: '10vh' }}>
-
-        <Card sx={{ width: '45vh', minHeight: '59vh', maxHeight: '100vh', marginBottom: '5vh' }}>
-          <CardMedia
+        <Box
+          className={styles.formContainer}
+          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: "10vh" }}
+        >
+          <Card sx={{ width: "45vh", minHeight: "59vh", maxHeight: "100vh", marginBottom: "5vh" }}>
+            <CardMedia
               component="img"
               image={event.eventCoverPhoto}
               alt={event.eventTitle}
-              sx={{ height: '37vh' }}
-          />
-          <CardContent>
-            <Typography gutterBottom variant="h5" component="div">
-              {event.eventTitle}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {event.eventDescription}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Date: {formatDate(event.eventDate)}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Start Time: {event.eventStartTime}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              End Time: {event.eventEndTime}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Location: {event.eventLocation}
-            </Typography>
-          </CardContent>
-        </Card>
-          <div style={ { width: '100vh', display: 'flex' }}>
-            <div style={ { display: 'flex', width: '100vh', gap: '25px',  justifyContent: 'center', alignItems: 'center', marginLeft: '13vh' } }>
+              sx={{ height: "37vh" }}
+            />
+            <CardContent>
+              <Typography gutterBottom variant="h5" component="div">
+                {event.eventTitle}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {event.eventDescription}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Date: {formatDate(event.eventDate)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Start Time: {event.eventStartTime}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                End Time: {event.eventEndTime}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Location: {event.eventLocation}
+              </Typography>
+            </CardContent>
+          </Card>
+          <div style={{ width: "100vh", display: "flex" }}>
+            <div
+              style={{
+                display: "flex",
+                width: "100vh",
+                gap: "25px",
+                justifyContent: "center",
+                alignItems: "center",
+                marginLeft: "13vh",
+              }}
+            >
               {isAuthed && (
-                  <>
-                    <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }} onClick={ () => { toggleEditDialog() }}> <EditIcon sx={ { marginRight: '5px' }}/> Edit </Button>
-                    <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }}   onClick={ () => setDialogOpen(true)} > <DeleteIcon sx={ { marginRight: '5px' }}/> Delete </Button>
-                    <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px' }} onClick={ () => toggleArchiveDialog() }> <ArchiveIcon sx={ { marginRight: '5px' }}/> Archive </Button>
-                  </>)
-              }
+                <>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => {
+                      toggleEditDialog();
+                    }}
+                  >
+                    {" "}
+                    <EditIcon sx={{ marginRight: "5px" }} /> Edit{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => setDialogOpen(true)}
+                  >
+                    {" "}
+                    <DeleteIcon sx={{ marginRight: "5px" }} /> Delete{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => toggleArchiveDialog()}
+                  >
+                    {" "}
+                    <ArchiveIcon sx={{ marginRight: "5px" }} /> Archive{" "}
+                  </Button>
+                </>
+              )}
             </div>
-            <Button variant='contained' sx={{ color:'white', backgroundColor: '#2074d4', width: '125px', marginRight: '50px' }} onClick={ () => { toggleAttendDialog()}}> Attend </Button>
+            <Button
+              variant="contained"
+              sx={{
+                color: "white",
+                backgroundColor: "#2074d4",
+                width: "125px",
+                marginRight: "50px",
+              }}
+              onClick={() => {
+                toggleViewMoreDetailsDialog();
+              }}
+            >
+              {" "}
+              More Details{" "}
+            </Button>
+            <Button
+              variant="contained"
+              sx={{
+                color: "white",
+                backgroundColor: "#2074d4",
+                width: "125px",
+                marginRight: "50px",
+              }}
+              onClick={() => {
+                toggleAttendDialog();
+              }}
+            >
+              {" "}
+              Attend{" "}
+            </Button>
           </div>
         </Box>
-        <DeleteDialog/>
-        <AttendDialog isOpen={attendDialogOpen} eventId={event._id} dialogToggle={toggleAttendDialog}/>
-        <ArchiveDialog isOpen={archiveDialogOpen} eventId={event._id} dialogToggle={toggleArchiveDialog}/>
-        <EditDialog isOpen={ editDialogOpen } event={event} toggleEditDialog={toggleEditDialog}/>
+        <DeleteDialog />
+        <ViewMoreDetailsDialog
+          isOpen={moreDetailsDialogOpen}
+          event={event}
+          userRole={userRole}
+          dialogToggle={toggleViewMoreDetailsDialog}
+        />
+        <AttendDialog
+          isOpen={attendDialogOpen}
+          eventId={event._id}
+          dialogToggle={toggleAttendDialog}
+        />
+        <ArchiveDialog
+          isOpen={archiveDialogOpen}
+          eventId={event._id}
+          dialogToggle={toggleArchiveDialog}
+        />
+        <EditDialog isOpen={editDialogOpen} event={event} toggleEditDialog={toggleEditDialog} />
         <Snackbar
-            open={Boolean(snackbarMessage)}
-            onClose={() => {
-              setSnackbarMessage("")
-            }}
-            autoHideDuration={1200}
-            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+          open={Boolean(snackbarMessage)}
+          onClose={() => {
+            setSnackbarMessage("");
+          }}
+          autoHideDuration={1200}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         >
-            <SnackbarContent
-              message={snackbarMessage}
-              sx={{ color: 'black' }}
-            />
+          <SnackbarContent message={snackbarMessage} sx={{ color: "black" }} />
         </Snackbar>
-
-</Box>
-
-</>
+      </Box>
+    </>
   );
-
 };
 
 export default EventDetail;

--- a/components/ViewMoreDetailsDialog.tsx
+++ b/components/ViewMoreDetailsDialog.tsx
@@ -1,0 +1,69 @@
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  Box,
+  Button,
+  DialogContentText,
+  Divider,
+  FormControlLabel,
+  ListItem,
+  ListItemText,
+  SnackbarContent,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import Snackbar from "@mui/material/Snackbar";
+import IconButton from "@mui/material/IconButton";
+import InfoIcon from "@mui/icons-material/Info";
+import React, { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { ActivityDatabase } from "@/models/activityDatabase";
+
+interface ViewMoreDetailsDialogProps {
+  isOpen: boolean;
+  event: ActivityDatabase;
+  userRole: string;
+  dialogToggle: () => void;
+}
+
+function ViewMoreDetailsDialog({
+  isOpen,
+  event,
+  userRole,
+  dialogToggle,
+}: ViewMoreDetailsDialogProps) {
+  const moreDetails = [
+    { title: "Event Host", detail: event.eventHost },
+    { title: "URL", detail: event.eventMeetingUrl },
+    { title: "Registration", detail: event.eventRegistration },
+    { title: "Tags", detail: event.eventTags },
+    { title: "Event Speakers", detail: event.eventSpeakers },
+    { title: "Event Contact", detail: event.eventContact },
+    { title: "Accessibility", detail: event.eventAccessibility },
+  ];
+
+  return (
+    <>
+      <Dialog open={isOpen}>
+        <DialogTitle>{"More Details:"}</DialogTitle>
+        <DialogContent dividers sx={{ height: "fit-content" }}>
+          {moreDetails.map((detail, id) => (
+            <ListItem key={id}>
+              <ListItemText primary={detail.title + ": " + detail.detail} />
+            </ListItem>
+          ))}
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={() => dialogToggle()}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+export default ViewMoreDetailsDialog;


### PR DESCRIPTION
Resolves #355 
This is the first part of the "View More Details" button feature. In this part, I focused strictly on getting the button to function for all user types. At this stage, each user type will have access to the same list of "More Details". In the next part I will focus on the extra fields that creators and admins will be able to view rather than normal users.

In order to test this, make sure you're on the correct branch: `nsc-events-07-355-event-details-page-2`
All you need to do is visit a few Event Detail pages and click on the "More Details" button located in the bottom right. Here's a demonstration of the test:

![](https://i.imgur.com/FjznYWS.gif)