### PR TITLE
nsc-events-nextjs-7-381-my-events-page-pagination

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -116,7 +116,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const { mutate: deleteEventMutation } = useMutation({
     mutationFn: deleteEvent,
      onSuccess: async () => {
-      await queryClient.refetchQueries({queryKey:['myEvents', 'events']});
+      await queryClient.refetchQueries({ queryKey:['myEvents', 'events'] });
       setSnackbarMessage("Successfully deleted event.");
       setTimeout(() => {
         router.push("/");

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -104,7 +104,8 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
   const { mutate: deleteEventMutation }  = useMutation({
     mutationFn: deleteEvent,
-     onSuccess: () => {
+     onSuccess: async () => {
+      await queryClient.refetchQueries({queryKey:['myEvents', 'events']});
       setSnackbarMessage("Successfully deleted event.");
       setTimeout( () => {
         router.push("/")

--- a/app/my-events/page.tsx
+++ b/app/my-events/page.tsx
@@ -15,9 +15,7 @@ const MyEvents = () => {
                     <h1>My Created Events</h1> 
                 </div>  
                 <div className={styles.eventContainer}>
-                    <div className={styles.homeEventsList}>
-                        <MyEventsList /> 
-                    </div>
+                    <MyEventsList />
                 </div>
             </div>   
         );

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -43,7 +43,7 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
         mutationFn: archiveEvent,
         onSuccess: async () => {
             setSnackbarMessage("Successfully archived event.");
-            await queryClient.refetchQueries({ queryKey: ['events'] });
+            await queryClient.refetchQueries({ queryKey: ['events', 'myEvents'] });
             setTimeout( () => {
                 router.push("/");
             }, 1200);

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { ActivityDatabase } from "@/models/activityDatabase";
-import { Grid } from "@mui/material";
+import { Button, Container, Grid } from "@mui/material";
 import { useEffect, useState } from "react";
 import EventCard from "./EventCard";
+import styles from '@/app/home.module.css'
+import { useMyEvents } from "@/utility/queries";
 
 // decode the userId from localStorage
 const getUserId = () => {
@@ -14,43 +16,51 @@ const getUserId = () => {
     }
     return null;
 }
-// fetch API endpoint that contains the user's created events
-const getMyEvents = async(userId: string) => {
-    const response = await fetch(`http://localhost:3000/api/events/user/${userId}`);
-    return response.json();
-}
-
 export function MyEventsList() {
     // useState to hold the events from the API call
     const [events, setEvents] = useState<ActivityDatabase[]>([]);
-    
+    const [page, setPage] = useState(1);
+    const [hasReachedLastPage, setHasReachedLastPage] = useState(false)
+    const { data } = useMyEvents(getUserId(), page);
     useEffect(() => {
-        const fetchEvents = async () => {
-            try {
-                // decode and grab the logged-in userId from localStorage
-                const userId = getUserId() 
-                if (userId){
-                    // pull user's events from endpoint 
-                    const myEvents = await getMyEvents(userId); 
-                    // set them to the useState hook
-                    setEvents(myEvents)
-                }
-            } catch (error) {
-                console.error("Error fetching user's events:", error);
-            }
-        };
-        fetchEvents();
-    }, []);
-
+        if (data) {
+            setEvents((prevEvents) => [...prevEvents, ...data]);
+            setHasReachedLastPage(data.length < 5)
+        }
+    }, [data]);
+    const handleLoadMoreEvents = () => {
+        setPage(page => page + 1)
+    }
     return (
-        <Grid container spacing={1}>
-                {events?.map((event: ActivityDatabase) => (
-                    <EventCard
-                        key={event._id} 
-                        event={event} 
-                    />
-                ))}
-        </Grid>
+        <Container maxWidth={false} className={styles.container}>
+            <Grid
+                container
+                direction={'column'}
+                spacing={1}
+                alignItems={'center'}
+                justifyItems={'center'}
+            >
+                    {events?.map((event: ActivityDatabase) => (
+                        <EventCard
+                            key={event._id}
+                            event={event}
+                        />
+                    ))}
+                {
+                    !hasReachedLastPage &&
+                    <Button onClick={handleLoadMoreEvents}
+                            type='button'
+                            variant="contained"
+                            color="primary"
+                            style={{
+                                textTransform: "none",
+                                margin: '1em auto',
+                            }}>
+                        Load more events
+                    </Button>
+                }
+            </Grid>
+        </Container>
     );
 }
 

--- a/hooks/useEditForm.tsx
+++ b/hooks/useEditForm.tsx
@@ -2,13 +2,13 @@ import { FormEvent, useEffect, useState } from "react";
 import { validateFormData } from "@/utility/validateFormData";
 import useDateTimeSelection from "./useDateTimeSelection";
 import { ActivityDatabase } from "@/models/activityDatabase";
-import { useMutation } from "@tanstack/react-query";
+import {useMutation, useQueryClient} from "@tanstack/react-query";
 import { useEventForm } from "@/hooks/useEventForm";
 import { format, parse } from "date-fns";
 
 export const useEditForm = (initialData: ActivityDatabase) => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-
+  const queryClient = useQueryClient();
   const {
     setEventData,
     setErrors,
@@ -114,7 +114,8 @@ const to24HourTime  = (time: string) => {
 
   const { mutate: editEventMutation }  = useMutation({
     mutationFn: editEvent,
-    onSuccess: () => {
+    onSuccess: async () => {
+      await queryClient.refetchQueries({queryKey:['myEvents', 'events']});
       setSuccessMessage( "Event successfully updated!");
       setTimeout( () => {
         window.location.reload()

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -3,6 +3,7 @@ import { validateFormData } from "@/utility/validateFormData";
 import { Activity, FormErrors } from "@/models/activity";
 import useDateTimeSelection from "./useDateTimeSelection";
 import { ActivityDatabase } from "@/models/activityDatabase";
+import { useQueryClient } from "@tanstack/react-query";
 
 export const useEventForm = (initialData: Activity | ActivityDatabase) => {
 
@@ -141,6 +142,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     console.log("Event data after applying transformation: ", dataToSend);
 
     try {
+      const queryClient = useQueryClient()
       const response = await fetch("http://localhost:3000/api/events/new", {
         method: "POST",
         headers: {
@@ -153,9 +155,9 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
       const data = await response.json();
       if (response.ok) {
         console.log("Activity created:", data);
+        await queryClient.refetchQueries({queryKey:['myEvents']})
         setSuccessMessage(data.message || "Event  successfully created!");
         setErrorMessage("");
-        
         // todo: navigate to a success page and clear form
       } else {
         console.log("Failed to create activity:", response.status);

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -153,7 +153,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
       const data = await response.json();
       if (response.ok) {
         console.log("Activity created:", data);
-        await queryClient.refetchQueries({queryKey:['myEvents']})
+        await queryClient.refetchQueries({queryKey:['myEvents', 'events']});
         setSuccessMessage(data.message || "Event  successfully created!");
         setErrorMessage("");
         // todo: navigate to a success page and clear form

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -40,7 +40,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
   // success/error messages for event creation
   const [successMessage, setSuccessMessage] = useState<String>("");
   const [errorMessage, setErrorMessage] = useState<String>("");
-
+  const queryClient = useQueryClient()
   // Use useDateTimeSelection hook
   const {
     startTime,
@@ -93,7 +93,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     });
   };
 
-  // converting time format to 12hr 
+  // converting time format to 12hr
   const to12HourTime = (time: string): string => {
      // returning an empty string if no time given
     if (!time) {
@@ -118,7 +118,6 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
       createActivity(eventData as Activity);
     }
   };
-
   const createActivity = async (activityData: Activity) => {
     // retrieving the token from localStorage
     const token = localStorage.getItem('token');
@@ -138,11 +137,10 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     if (typeof dataToSend.eventSpeakers === 'string') {
       dataToSend.eventSpeakers = [dataToSend.eventSpeakers];
     }
-    
+
     console.log("Event data after applying transformation: ", dataToSend);
 
     try {
-      const queryClient = useQueryClient()
       const response = await fetch("http://localhost:3000/api/events/new", {
         method: "POST",
         headers: {

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -15,3 +15,18 @@ export function useFilteredEvents() {
         }),
     });
 }
+
+const getMyEvents = async(userId: string, page: any) => {
+    const params = new URLSearchParams({
+        page: String(page),
+        numEvents: String(5),
+    });
+    const response = await fetch(`http://localhost:3000/api/events/user/${userId}?${String(params)}`);
+    return response.json();
+}
+export function useMyEvents(userId: string, page: any) {
+    return useQuery<ActivityDatabase[], Error>({
+        queryKey: ["myEvents", page],
+        queryFn: async () => getMyEvents(userId, page),
+    });
+}


### PR DESCRIPTION
### Note this PR depends on SeattleColleges/nsc-events-nestjs#120. Please check out branch `refactor-120-update-get-events-by-user-controller` in the backend repo when testing these changes.
This PR implements pagination on the My Events page. It also implements the functionality to refetch queries on any event mutation (add, update, delete, archive). Without this safeguard, duplicate events can be fetched, leading to unexpected behavior regarding the pagination.  5 events are loaded by default, and another 5 will be loaded and rendered every time the "Load more events" button is clicked until the current page returns less than 5 events signifying it is the last page so the button will be hidden. There is the case where the last page returns 5 events. This means clicking the Load More Events button will disappear but no new events will render. My thought would be to add API route that returns a count of events given a certain query, but there may be a better way that I'm not aware of currently. 


https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/244094e8-ff05-4000-a997-67cc5d14d0a0

