### PR TITLE
Revert "nsc-events-nextjs_7_295_arrow_icons"

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -245,7 +245,9 @@ const EventDetail = ({ searchParams }: SearchParams) => {
                     {" "}
                     <ArchiveIcon sx={{ marginRight: "5px" }} /> Archive{" "}
                   </Button>
-                  <Button
+                </>
+              )}
+              <Button
                     variant="contained"
                     sx={{
                       color: "white",
@@ -273,8 +275,6 @@ const EventDetail = ({ searchParams }: SearchParams) => {
                     {" "}
                     Attend{" "}
                   </Button>
-                </>
-              )}
             </div>
           </div>
         </Box>

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -1,6 +1,4 @@
-
-'use client';
-
+"use client";
 
 import React, { useEffect, useState } from "react";
 import {
@@ -32,9 +30,6 @@ import EditDialog from "@/components/EditDialog";
 import { formatDate } from "@/utility/dateUtils";
 import ViewMoreDetailsDialog from "@/components/ViewMoreDetailsDialog";
 
-import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-
 interface SearchParams {
   searchParams: {
     id: string;
@@ -43,11 +38,7 @@ interface SearchParams {
 
 const EventDetail = ({ searchParams }: SearchParams) => {
   const router = useRouter();
-
-  const [event, setEvent] = useState<ActivityDatabase>(activityDatabase);
-  const [events, setEvents] = useState<ActivityDatabase[]>([]);
-  const [isAuthed, setAuthed] = useState(false);
-
+  const [event, setEvent] = useState(activityDatabase);
   const [token, setToken] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
@@ -59,33 +50,44 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const [userRole, setUserRole] = useState("");
   const queryClient = useQueryClient();
 
-  const DeleteDialog = () => (
-    <Dialog
-      open={dialogOpen}
-      onClose={() => setDialogOpen(false)}
-      aria-describedby="Dialogue to confirm event deletion"
-    >
-      <DialogTitle>{"Delete Event?"}</DialogTitle>
-      <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          Are you sure you want to delete this event?
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
-        <Button
-          onClick={() => {
-            deleteEventMutation(event._id);
+  const DeleteDialog = () => {
+    return (
+      <>
+        <Dialog
+          open={dialogOpen}
+          onClose={() => {
             setDialogOpen(false);
           }}
-          autoFocus
+          aria-describedby="Dialogue to confirm event deletion"
         >
-          Delete
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-
+          <DialogTitle>{"Delete Event?"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              Are you sure you want to delete this event?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                setDialogOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                deleteEventMutation(event._id);
+                setDialogOpen(false);
+              }}
+              autoFocus
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  };
 
   const toggleEditDialog = () => {
     setEditDialogOpen(!editDialogOpen);
@@ -94,17 +96,20 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const deleteEvent = async (id: string) => {
     try {
       const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
-        method: 'DELETE',
-
+        method: "DELETE",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
       });
+      console.log(response);
+      if (!response.ok) {
+        throw new Error(`Failed to delete event: ${response.statusText}`);
+      }
       return response.json();
     } catch (error) {
-      console.error('error: ', error);
-
+      console.error("error: ", error);
+      throw error;
     }
   };
 
@@ -118,137 +123,191 @@ const EventDetail = ({ searchParams }: SearchParams) => {
     },
     onError: () => {
       setSnackbarMessage("Failed to delete event.");
-    }
+    },
   });
 
   useEffect(() => {
     const getEvents = async () => {
-      const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
+      const events = queryClient.getQueryData<ActivityDatabase[]>(["event"]);
       if (events !== undefined) {
-        setEvents(events);
-        const selectedEvent = events.find(event => event._id === searchParams.id) as ActivityDatabase;
-
+        const selectedEvent = events.find(
+          (event) => event._id === searchParams.id
+        ) as ActivityDatabase;
         setEvent(selectedEvent);
       } else if (searchParams.id) {
         const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
         if (response.ok) {
-          const evt = await response.json();
-          setEvent(evt);
-          setEvents([evt]); // assuming there's only one event in response
-
+          await response.json().then((evt) => setEvent(evt));
         }
       }
     };
     getEvents();
     const token = localStorage.getItem("token");
+    // Sets token state that is used by delete mutation outside of effect
     setToken(token ?? "");
 
     if (token) {
-      const userRole = JSON.parse(atob(token.split(".")[1])).role;
-      setAuthed(userRole === "creator" || userRole === "admin");
+      const role = JSON.parse(atob(token.split(".")[1])).role;
+      const id = JSON.parse(atob(token.split(".")[1])).id;
+      setUserRole(role);
+      setUserId(id);
     }
-  }, [queryClient, searchParams.id]);
+  }, [queryClient, searchParams.id, token, userId]);
 
   const toggleAttendDialog = () => {
-    if (token === '') {
+    if (token === "") {
+      console.log(token);
       router.push("auth/sign-in");
     } else {
       setAttendDialogOpen(!attendDialogOpen);
     }
   };
 
+  const toggleViewMoreDetailsDialog = () => {
+    setMoreDetailsDialogOpen(!moreDetailsDialogOpen);
+  };
+
   const toggleArchiveDialog = () => {
     setArchiveDialogOpen(!archiveDialogOpen);
   };
 
-  const getNextEvent = () => {
-    const currentIndex = events.findIndex(e => e._id === event._id);
-    if (currentIndex < events.length - 1) {
-      const nextEvent = events[currentIndex + 1];
-      router.push(`/eventDetails?id=${nextEvent._id}`);
-    }
-  };
-
-  const getPrevEvent = () => {
-    const currentIndex = events.findIndex(e => e._id === event._id);
-    if (currentIndex > 0) {
-      const prevEvent = events[currentIndex - 1];
-      router.push(`/eventDetails?id=${prevEvent._id}`);
-    }
-  };
-
   return (
-    <Box className={styles.container}>
-      <Button onClick={getPrevEvent}>
-        <ArrowBackIosIcon sx={{ color: 'white', fontSize: '100px' }} />
-      </Button>
-      <Box className={styles.formContainer} sx={{ minHeight: '69vh', maxHeight: '100vh', width: '100vh', marginTop: '10vh' }}>
-        <Card sx={{ width: '45vh', minHeight: '59vh', maxHeight: '100vh', marginBottom: '5vh' }}>
-          <CardMedia
-            component="img"
-            image={event.eventCoverPhoto}
-            alt={event.eventTitle}
-            sx={{ height: '37vh' }}
-          />
-          <CardContent>
-            <Typography gutterBottom variant="h5" component="div">
-              {event.eventTitle}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {event.eventDescription}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Date: {formatDate(event.eventDate)}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Start Time: {event.eventStartTime}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              End Time: {event.eventEndTime}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Location: {event.eventLocation}
-            </Typography>
-          </CardContent>
-        </Card>
-        <div style={{ width: '100vh', display: 'flex' }}>
-          <div style={{ display: 'flex', width: '100vh', gap: '25px', justifyContent: 'center', alignItems: 'center', marginLeft: '13vh' }}>
-            {isAuthed && (
-              <>
-                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={toggleEditDialog}>
-                  <EditIcon sx={{ marginRight: '5px' }} /> Edit
-                </Button>
-                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={() => setDialogOpen(true)}>
-                  <DeleteIcon sx={{ marginRight: '5px' }} /> Delete
-                </Button>
-                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={toggleArchiveDialog}>
-                  <ArchiveIcon sx={{ marginRight: '5px' }} /> Archive
-                </Button>
-              </>
-            )}
+    <>
+      <Box className={styles.container}>
+        <Box
+          className={styles.formContainer}
+          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: "10vh" }}
+        >
+          <Card sx={{ width: "45vh", minHeight: "59vh", maxHeight: "100vh", marginBottom: "5vh" }}>
+            <CardMedia
+              component="img"
+              image={event.eventCoverPhoto}
+              alt={event.eventTitle}
+              sx={{ height: "37vh" }}
+            />
+            <CardContent>
+              <Typography gutterBottom variant="h5" component="div">
+                {event.eventTitle}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {event.eventDescription}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Date: {formatDate(event.eventDate)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Start Time: {event.eventStartTime}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                End Time: {event.eventEndTime}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Location: {event.eventLocation}
+              </Typography>
+            </CardContent>
+          </Card>
+          <div style={{ width: "100vh", display: "flex" }}>
+            <div
+              style={{
+                display: "flex",
+                width: "100vh",
+                gap: "25px",
+                justifyContent: "center",
+                alignItems: "center",
+              }}
+            >
+              {(userRole === "admin" ||
+                (userRole === "creator" && event?.createdByUser === userId)) && (
+                <>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => {
+                      toggleEditDialog();
+                    }}
+                  >
+                    {" "}
+                    <EditIcon sx={{ marginRight: "5px" }} /> Edit{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => setDialogOpen(true)}
+                  >
+                    {" "}
+                    <DeleteIcon sx={{ marginRight: "5px" }} /> Delete{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => toggleArchiveDialog()}
+                  >
+                    {" "}
+                    <ArchiveIcon sx={{ marginRight: "5px" }} /> Archive{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{
+                      color: "white",
+                      backgroundColor: "#2074d4",
+                      width: "140px",
+                    }}
+                    onClick={() => {
+                      toggleViewMoreDetailsDialog();
+                    }}
+                  >
+                    {" "}
+                    More Details{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{
+                      color: "white",
+                      backgroundColor: "#2074d4",
+                      width: "125px",
+                    }}
+                    onClick={() => {
+                      toggleAttendDialog();
+                    }}
+                  >
+                    {" "}
+                    Attend{" "}
+                  </Button>
+                </>
+              )}
+            </div>
           </div>
-          <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px', marginRight: '50px' }} onClick={toggleAttendDialog}>
-            Attend
-          </Button>
-        </div>
+        </Box>
+        <DeleteDialog />
+        <ViewMoreDetailsDialog
+          isOpen={moreDetailsDialogOpen}
+          event={event}
+          userRole={userRole}
+          dialogToggle={toggleViewMoreDetailsDialog}
+        />
+        <AttendDialog
+          isOpen={attendDialogOpen}
+          eventId={event._id}
+          dialogToggle={toggleAttendDialog}
+        />
+        <ArchiveDialog
+          isOpen={archiveDialogOpen}
+          eventId={event._id}
+          dialogToggle={toggleArchiveDialog}
+        />
+        <EditDialog isOpen={editDialogOpen} event={event} toggleEditDialog={toggleEditDialog} />
+        <Snackbar
+          open={Boolean(snackbarMessage)}
+          onClose={() => {
+            setSnackbarMessage("");
+          }}
+          autoHideDuration={1200}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        >
+          <SnackbarContent message={snackbarMessage} sx={{ color: "black" }} />
+        </Snackbar>
       </Box>
-      <DeleteDialog />
-      <AttendDialog isOpen={attendDialogOpen} eventId={event._id} dialogToggle={toggleAttendDialog} />
-      <ArchiveDialog isOpen={archiveDialogOpen} eventId={event._id} dialogToggle={toggleArchiveDialog} />
-      <EditDialog isOpen={editDialogOpen} event={event} toggleEditDialog={toggleEditDialog} />
-      <Snackbar
-        open={Boolean(snackbarMessage)}
-        onClose={() => setSnackbarMessage('')}
-        autoHideDuration={1200}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-        message={snackbarMessage}
-      />
-
-      <Button onClick={getNextEvent}>
-        <ArrowForwardIosIcon sx={{ color: 'white', fontSize: '100px' }} />
-      </Button>
-    </Box>
-
+    </>
   );
 };
 


### PR DESCRIPTION
Reverts SeattleColleges/nsc-events-nextjs#364


[This PR](https://github.com/SeattleColleges/nsc-events-nextjs/pull/364) conflicted with two other PRs:
https://github.com/SeattleColleges/nsc-events-nextjs/pull/369
https://github.com/SeattleColleges/nsc-events-nextjs/pull/363

It seems that the branch conflicts were resolved incorrectly, which resulted in the changes of these other PRs being removed. This PR reverts the changes in [this PR](https://github.com/SeattleColleges/nsc-events-nextjs/pull/364) and then adds the changes (such as the arrow icons) again. It also fixes the "More Details" and "Attend" buttons not appearing for users and creators (when viewing events that aren't their own).
