### PR TITLE
nsc-nextjs-chore-add-deployed-api-url

### DIFF
--- a/app/auth/sign-up/signupApi.tsx
+++ b/app/auth/sign-up/signupApi.tsx
@@ -1,4 +1,4 @@
-const URL = process.env.NSC_EVENTS_PUBLIC_API_URL + "/auth/signup" || "http://localhost:3000/api/auth/signup";
+const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 interface SignUpPayload {
   firstName: string;
   lastName: string;
@@ -24,7 +24,7 @@ export const signUp = async (
   payload: SignUpPayload
 ): Promise<SignUpResponse> => {
   try {
-    const response = await fetch(URL, {
+    const response = await fetch(`${apiUrl}/auth/signup`, {
       method: "POST",
       body: JSON.stringify(payload),
       headers: { "Content-Type": "application/json" },

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -19,9 +19,9 @@ interface User {
  */
 async function fetchUser(setUserInfo: (userInfo: User[]) => void) {
   const token = localStorage.getItem("token");
-  const apiUrl = "http://localhost:3000/api/users";
+  const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
   try {
-    const res = await fetch(apiUrl, {
+    const res = await fetch(`${apiUrl}/users`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -93,7 +93,8 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
   const deleteEvent = async (id: string) => {
     try {
-      const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/events/remove/${id}`, {
         method: 'DELETE',
 
         headers: {
@@ -130,7 +131,8 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
         setEvent(selectedEvent);
       } else if (searchParams.id) {
-        const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
+        const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+        const response = await fetch(`${apiUrl}/events/find/${searchParams.id}`);
         if (response.ok) {
           const evt = await response.json();
           setEvent(evt);

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -22,7 +22,8 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
     const archiveEvent = async (id: string) => {
         const token = localStorage.getItem("token");
         try {
-            const response = await fetch(`http://localhost:3000/api/events/archive/${id}`, {
+            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+            const response = await fetch(`${apiUrl}/events/archive/${id}`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',

--- a/components/AttendDialog.tsx
+++ b/components/AttendDialog.tsx
@@ -52,7 +52,8 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
         }
 
         try {
-            const response = await fetch(`http://localhost:3000/api/events/attend/${id}`, options );
+            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+            const response = await fetch(`${apiUrl}/events/attend/${id}`, options );
             return response.json();
         } catch (error) {
             console.error('error: ', error)

--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -74,7 +74,8 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
     console.log('Token:', token);
     // TODO: Update user role in the database
     try {
-      const response = await fetch(`http://localhost:3000/api/users/update/${user.id}`, {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/users/update/${user.id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -12,7 +12,8 @@ export function HomeEventsList(){
     const [events, setEvents] = useState<ActivityDatabase[] | undefined>([]);
     const [reachedMaxEvents, setReachedMaxEvents] = useState(false)
     const getNumEvents = async(numEvents: number) => {
-        const response = await fetch(`http://localhost:3000/api/events?numEvents=${numEvents}`);
+        const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+        const response = await fetch(`${apiUrl}/events?numEvents=${numEvents}`);
         return response.json();
     }
     useEffect(() => {

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -16,7 +16,8 @@ const getUserId = () => {
 }
 // fetch API endpoint that contains the user's created events
 const getMyEvents = async(userId: string) => {
-    const response = await fetch(`http://localhost:3000/api/events/user/${userId}`);
+    const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+    const response = await fetch(`${apiUrl}/events/user/${userId}`);
     return response.json();
 }
 

--- a/hooks/useEditForm.tsx
+++ b/hooks/useEditForm.tsx
@@ -89,7 +89,8 @@ const to24HourTime  = (time: string) => {
 
 
     try {
-      const response = await fetch(`http://localhost:3000/api/events/update/${dataToSend._id}`, {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/events/update/${dataToSend._id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -141,7 +141,8 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     console.log("Event data after applying transformation: ", dataToSend);
 
     try {
-      const response = await fetch("http://localhost:3000/api/events/new", {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch("${apiUrl}/events/new", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   env: {
     // TODO: PULL THIS FROM GITHUB ACTIONS
     // NSC_EVENTS_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-    //NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
+    NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
   },
 }
 

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -1,9 +1,9 @@
-import {useQuery} from "@tanstack/react-query";
-import {ActivityDatabase} from "@/models/activityDatabase";
+import { useQuery } from "@tanstack/react-query";
+import { ActivityDatabase } from "@/models/activityDatabase";
 import React from "react";
-
+const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 const getEvents = async() => {
-    const response = await fetch(`http://localhost:3000/api/events`);
+    const response = await fetch(`${apiUrl}/events`);
     return response.json();
 }
 export function useFilteredEvents() {
@@ -23,7 +23,7 @@ const getArchivedEvents = async(page: any) => {
         numEvents: String(5),
         isArchived: String(true)
     });
-    const response = await fetch(`http://localhost:3000/api/events?${String(params)}`);
+    const response = await fetch(`${apiUrl}/events?${String(params)}`);
     return response.json();
 }
 export function useArchivedEvents(page: any) {


### PR DESCRIPTION
Resolves #390 

This PR will add the deployed API URL to allow the deployed servers to retrieve and request data.

_**Note: To test this PR, you only need to run the local front end, the backend is already connected to the deployed server. You will see the same result as the screenshot below.**_

### Result

![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/72054441/abc6dbc2-4fcd-4a60-8688-ed5380c3739c)
