### PR TITLE
nsc-events-nextjs-7-386-view-more-details-role-accessibility

### DIFF
--- a/app/auth/sign-up/signupApi.tsx
+++ b/app/auth/sign-up/signupApi.tsx
@@ -1,4 +1,4 @@
-const URL = process.env.NSC_EVENTS_PUBLIC_API_URL + "/auth/signup" || "http://localhost:3000/api/auth/signup";
+const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 interface SignUpPayload {
   firstName: string;
   lastName: string;
@@ -24,7 +24,7 @@ export const signUp = async (
   payload: SignUpPayload
 ): Promise<SignUpResponse> => {
   try {
-    const response = await fetch(URL, {
+    const response = await fetch(`${apiUrl}/auth/signup`, {
       method: "POST",
       body: JSON.stringify(payload),
       headers: { "Content-Type": "application/json" },

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -19,9 +19,9 @@ interface User {
  */
 async function fetchUser(setUserInfo: (userInfo: User[]) => void) {
   const token = localStorage.getItem("token");
-  const apiUrl = "http://localhost:3000/api/users";
+  const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
   try {
-    const res = await fetch(apiUrl, {
+    const res = await fetch(`${apiUrl}/users`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -1,6 +1,4 @@
-
-'use client';
-
+"use client";
 
 import React, { useEffect, useState } from "react";
 import {
@@ -28,10 +26,8 @@ import { useRouter } from "next/navigation";
 import AttendDialog from "@/components/AttendDialog";
 import ArchiveDialog from "@/components/ArchiveDialog";
 import EditDialog from "@/components/EditDialog";
-
 import { formatDate } from "@/utility/dateUtils";
 import ViewMoreDetailsDialog from "@/components/ViewMoreDetailsDialog";
-
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 
@@ -43,11 +39,9 @@ interface SearchParams {
 
 const EventDetail = ({ searchParams }: SearchParams) => {
   const router = useRouter();
-
   const [event, setEvent] = useState<ActivityDatabase>(activityDatabase);
   const [events, setEvents] = useState<ActivityDatabase[]>([]);
   const [isAuthed, setAuthed] = useState(false);
-
   const [token, setToken] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
@@ -59,33 +53,44 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const [userRole, setUserRole] = useState("");
   const queryClient = useQueryClient();
 
-  const DeleteDialog = () => (
-    <Dialog
-      open={dialogOpen}
-      onClose={() => setDialogOpen(false)}
-      aria-describedby="Dialogue to confirm event deletion"
-    >
-      <DialogTitle>{"Delete Event?"}</DialogTitle>
-      <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          Are you sure you want to delete this event?
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
-        <Button
-          onClick={() => {
-            deleteEventMutation(event._id);
+  const DeleteDialog = () => {
+    return (
+      <>
+        <Dialog
+          open={dialogOpen}
+          onClose={() => {
             setDialogOpen(false);
           }}
           autoFocus
         >
-          Delete
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-
+          <DialogTitle>{"Delete Event?"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              Are you sure you want to delete this event?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                setDialogOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                deleteEventMutation(event._id);
+                setDialogOpen(false);
+              }}
+              autoFocus
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  };
 
   const toggleEditDialog = () => {
     setEditDialogOpen(!editDialogOpen);
@@ -96,16 +101,19 @@ const EventDetail = ({ searchParams }: SearchParams) => {
       const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
       const response = await fetch(`${apiUrl}/events/remove/${id}`, {
         method: 'DELETE',
-
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
       });
+      console.log(response);
+      if (!response.ok) {
+        throw new Error(`Failed to delete event: ${response.statusText}`);
+      }
       return response.json();
     } catch (error) {
-      console.error('error: ', error);
-
+      console.error("error: ", error);
+      throw error;
     }
   };
 
@@ -120,16 +128,15 @@ const EventDetail = ({ searchParams }: SearchParams) => {
     },
     onError: () => {
       setSnackbarMessage("Failed to delete event.");
-    }
+    },
   });
 
   useEffect(() => {
     const getEvents = async () => {
-      const events = queryClient.getQueryData<ActivityDatabase[]>(['event']);
+      const events = queryClient.getQueryData<ActivityDatabase[]>(["event"]);
       if (events !== undefined) {
         setEvents(events);
         const selectedEvent = events.find(event => event._id === searchParams.id) as ActivityDatabase;
-
         setEvent(selectedEvent);
       } else if (searchParams.id) {
         const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
@@ -138,26 +145,33 @@ const EventDetail = ({ searchParams }: SearchParams) => {
           const evt = await response.json();
           setEvent(evt);
           setEvents([evt]); // assuming there's only one event in response
-
         }
       }
     };
     getEvents();
     const token = localStorage.getItem("token");
+    // Sets token state that is used by delete mutation outside of effect
     setToken(token ?? "");
 
     if (token) {
-      const userRole = JSON.parse(atob(token.split(".")[1])).role;
-      setAuthed(userRole === "creator" || userRole === "admin");
+      const role = JSON.parse(atob(token.split(".")[1])).role;
+      const id = JSON.parse(atob(token.split(".")[1])).id;
+      setUserRole(role);
+      setUserId(id);
     }
   }, [queryClient, searchParams.id]);
 
   const toggleAttendDialog = () => {
-    if (token === '') {
+    if (token === "") {
+      console.log(token);
       router.push("auth/sign-in");
     } else {
       setAttendDialogOpen(!attendDialogOpen);
     }
+  };
+
+  const toggleViewMoreDetailsDialog = () => {
+    setMoreDetailsDialogOpen(!moreDetailsDialogOpen);
   };
 
   const toggleArchiveDialog = () => {
@@ -181,77 +195,148 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   };
 
   return (
-    <Box className={styles.container}>
-      <Button onClick={getPrevEvent}>
-        <ArrowBackIosIcon sx={{ color: 'white', fontSize: '100px' }} />
-      </Button>
-      <Box className={styles.formContainer} sx={{ minHeight: '69vh', maxHeight: '100vh', width: '100vh', marginTop: '10vh' }}>
-        <Card sx={{ width: '45vh', minHeight: '59vh', maxHeight: '100vh', marginBottom: '5vh' }}>
-          <CardMedia
-            component="img"
-            image={event.eventCoverPhoto}
-            alt={event.eventTitle}
-            sx={{ height: '37vh' }}
-          />
-          <CardContent>
-            <Typography gutterBottom variant="h5" component="div">
-              {event.eventTitle}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {event.eventDescription}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Date: {formatDate(event.eventDate)}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Start Time: {event.eventStartTime}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              End Time: {event.eventEndTime}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Location: {event.eventLocation}
-            </Typography>
-          </CardContent>
-        </Card>
-        <div style={{ width: '100vh', display: 'flex' }}>
-          <div style={{ display: 'flex', width: '100vh', gap: '25px', justifyContent: 'center', alignItems: 'center', marginLeft: '13vh' }}>
-            {isAuthed && (
-              <>
-                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={toggleEditDialog}>
-                  <EditIcon sx={{ marginRight: '5px' }} /> Edit
-                </Button>
-                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={() => setDialogOpen(true)}>
-                  <DeleteIcon sx={{ marginRight: '5px' }} /> Delete
-                </Button>
-                <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px' }} onClick={toggleArchiveDialog}>
-                  <ArchiveIcon sx={{ marginRight: '5px' }} /> Archive
-                </Button>
-              </>
-            )}
+    <>
+      <Box className={styles.container}>
+        <Button onClick={getPrevEvent}>
+          <ArrowBackIosIcon sx={{ color: 'white', fontSize: '100px' }} />
+        </Button>
+        <Box
+          className={styles.formContainer}
+          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: "10vh" }}
+        >
+          <Card sx={{ width: "45vh", minHeight: "59vh", maxHeight: "100vh", marginBottom: "5vh" }}>
+            <CardMedia
+              component="img"
+              image={event.eventCoverPhoto}
+              alt={event.eventTitle}
+              sx={{ height: "37vh" }}
+            />
+            <CardContent>
+              <Typography gutterBottom variant="h5" component="div">
+                {event.eventTitle}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {event.eventDescription}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Date: {formatDate(event.eventDate)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Start Time: {event.eventStartTime}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                End Time: {event.eventEndTime}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Location: {event.eventLocation}
+              </Typography>
+            </CardContent>
+          </Card>
+          <div style={{ width: "100vh", display: "flex" }}>
+            <div
+              style={{
+                display: "flex",
+                width: "100vh",
+                gap: "25px",
+                justifyContent: "center",
+                alignItems: "center",
+              }}
+            >
+              {(userRole === "admin" ||
+                (userRole === "creator" && event?.createdByUser === userId)) && (
+                <>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => {
+                      toggleEditDialog();
+                    }}
+                  >
+                    {" "}
+                    <EditIcon sx={{ marginRight: "5px" }} /> Edit{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => setDialogOpen(true)}
+                  >
+                    {" "}
+                    <DeleteIcon sx={{ marginRight: "5px" }} /> Delete{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
+                    onClick={() => toggleArchiveDialog()}
+                  >
+                    {" "}
+                    <ArchiveIcon sx={{ marginRight: "5px" }} /> Archive{" "}
+                  </Button>
+                </>
+              )}
+              <Button
+                    variant="contained"
+                    sx={{
+                      color: "white",
+                      backgroundColor: "#2074d4",
+                      width: "140px",
+                    }}
+                    onClick={() => {
+                      toggleViewMoreDetailsDialog();
+                    }}
+                  >
+                    {" "}
+                    More Details{" "}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    sx={{
+                      color: "white",
+                      backgroundColor: "#2074d4",
+                      width: "125px",
+                    }}
+                    onClick={() => {
+                      toggleAttendDialog();
+                    }}
+                  >
+                    {" "}
+                    Attend{" "}
+                  </Button>
+            </div>
           </div>
-          <Button variant='contained' sx={{ color: 'white', backgroundColor: '#2074d4', width: '125px', marginRight: '50px' }} onClick={toggleAttendDialog}>
-            Attend
-          </Button>
-        </div>
-      </Box>
-      <DeleteDialog />
-      <AttendDialog isOpen={attendDialogOpen} eventId={event._id} dialogToggle={toggleAttendDialog} />
-      <ArchiveDialog isOpen={archiveDialogOpen} eventId={event._id} dialogToggle={toggleArchiveDialog} />
-      <EditDialog isOpen={editDialogOpen} event={event} toggleEditDialog={toggleEditDialog} />
-      <Snackbar
-        open={Boolean(snackbarMessage)}
-        onClose={() => setSnackbarMessage('')}
-        autoHideDuration={1200}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-        message={snackbarMessage}
-      />
-
-      <Button onClick={getNextEvent}>
+        </Box>
+        <DeleteDialog />
+        <ViewMoreDetailsDialog
+          isOpen={moreDetailsDialogOpen}
+          event={event}
+          userRole={userRole}
+          dialogToggle={toggleViewMoreDetailsDialog}
+        />
+        <AttendDialog
+          isOpen={attendDialogOpen}
+          eventId={event._id}
+          dialogToggle={toggleAttendDialog}
+        />
+        <ArchiveDialog
+          isOpen={archiveDialogOpen}
+          eventId={event._id}
+          dialogToggle={toggleArchiveDialog}
+        />
+        <EditDialog isOpen={editDialogOpen} event={event} toggleEditDialog={toggleEditDialog} />
+        <Snackbar
+          open={Boolean(snackbarMessage)}
+          onClose={() => {
+            setSnackbarMessage("");
+          }}
+          autoHideDuration={1200}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        >
+          <SnackbarContent message={snackbarMessage} sx={{ color: "black" }} />
+        </Snackbar>
+        <Button onClick={getNextEvent}>
         <ArrowForwardIosIcon sx={{ color: 'white', fontSize: '100px' }} />
-      </Button>
-    </Box>
-
+        </Button>
+      </Box>
+    </>
   );
 };
 

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -93,7 +93,8 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
   const deleteEvent = async (id: string) => {
     try {
-      const response = await fetch(`http://localhost:3000/api/events/remove/${id}`, {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/events/remove/${id}`, {
         method: 'DELETE',
 
         headers: {
@@ -131,7 +132,8 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
         setEvent(selectedEvent);
       } else if (searchParams.id) {
-        const response = await fetch(`http://localhost:3000/api/events/find/${searchParams.id}`);
+        const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+        const response = await fetch(`${apiUrl}/events/find/${searchParams.id}`);
         if (response.ok) {
           const evt = await response.json();
           setEvent(evt);

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -22,7 +22,8 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
     const archiveEvent = async (id: string) => {
         const token = localStorage.getItem("token");
         try {
-            const response = await fetch(`http://localhost:3000/api/events/archive/${id}`, {
+            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+            const response = await fetch(`${apiUrl}/events/archive/${id}`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',

--- a/components/AttendDialog.tsx
+++ b/components/AttendDialog.tsx
@@ -52,7 +52,8 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
         }
 
         try {
-            const response = await fetch(`http://localhost:3000/api/events/attend/${id}`, options );
+            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+            const response = await fetch(`${apiUrl}/events/attend/${id}`, options );
             return response.json();
         } catch (error) {
             console.error('error: ', error)

--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -71,7 +71,8 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user
   const handleOk = async () => {
     const token = localStorage.getItem('token');
     try {
-      const response = await fetch(`http://localhost:3000/api/users/update/${user.id}`, {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/users/update/${user.id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -16,6 +16,13 @@ const getUserId = () => {
     }
     return null;
 }
+// fetch API endpoint that contains the user's created events
+const getMyEvents = async(userId: string) => {
+    const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+    const response = await fetch(`${apiUrl}/events/user/${userId}`);
+    return response.json();
+}
+
 export function MyEventsList() {
     // useState to hold the events from the API call
     const [events, setEvents] = useState<ActivityDatabase[]>([]);

--- a/hooks/useEditForm.tsx
+++ b/hooks/useEditForm.tsx
@@ -89,7 +89,8 @@ const to24HourTime  = (time: string) => {
 
 
     try {
-      const response = await fetch(`http://localhost:3000/api/events/update/${dataToSend._id}`, {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/events/update/${dataToSend._id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -141,7 +141,8 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     console.log("Event data after applying transformation: ", dataToSend);
 
     try {
-      const response = await fetch("http://localhost:3000/api/events/new", {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch("${apiUrl}/events/new", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   env: {
     // TODO: PULL THIS FROM GITHUB ACTIONS
     // NSC_EVENTS_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-    //NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
+    NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
   },
 }
 

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -1,13 +1,14 @@
-import {useQuery} from "@tanstack/react-query";
-import {ActivityDatabase} from "@/models/activityDatabase";
+import { useQuery } from "@tanstack/react-query";
+import { ActivityDatabase } from "@/models/activityDatabase";
 import React from "react";
 
+const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 const getEvents = async(page: any) => {
     const params = new URLSearchParams({
         page: String(page),
         isArchived: String(false),
     });
-    const response = await fetch(`http://localhost:3000/api/events?${params.toString()}`);
+    const response = await fetch(`${apiUrl}/events?${params.toString()}`);
     return response.json();
 }
 export function useFilteredEvents(page: any) {
@@ -23,7 +24,7 @@ const getArchivedEvents = async(page: any) => {
         numEvents: String(5),
         isArchived: String(true)
     });
-    const response = await fetch(`http://localhost:3000/api/events?${String(params)}`);
+    const response = await fetch(`${apiUrl}/events?${String(params)}`);
     return response.json();
 }
 export function useArchivedEvents(page: any) {
@@ -38,7 +39,7 @@ const getMyEvents = async(userId: string, page: any) => {
         page: String(page),
         numEvents: String(5),
     });
-    const response = await fetch(`http://localhost:3000/api/events/user/${userId}?${String(params)}`);
+    const response = await fetch(`${apiUrl}/events/user/${userId}?${String(params)}`);
     return response.json();
 }
 export function useMyEvents(userId: string, page: any) {


### PR DESCRIPTION
Resolves #386 

### This PR gives creators and admins access to more event details than a normal user:

- I started off by grouping the event data based on user type into object arrays. 

- Then I created a mapDetails function that will parse through each array. It will first check if the detail type is an object and map that data accordingly. 

- As it stands now, the only object that gets parsed separately is the eventSocialMedia detail which is an object that contains four different social media website info. All of the other event details gets mapped normally.

- All details that get mapped are turned into a <ListItem> and displayed with <ListItemText>.

### User Access:
- Event Host, Event Meeting URL, Event Registration, Event Tags, Event Speakers, Event Contact, Event Accessibility

### Creator Access:

- Everything else except Event Note

### Admin Access:

- All details including Event Note

### For testing this PR:

Make sure to have one of each user, creator, and admin accounts. Log into all three of them and view a specific event pages extra details by pressing the "More Details" button.

I tried to comment the code as best as I can so you guys can understand the process of how each role gets access to specific details. If you have any suggestions or a different way to approach this problem, please comment below! 

I noticed that eventMeetingURL isn't part of the database on the backend nest-js (it's being returned as undefined). If this hasn't been addressed yet, we probably need to add that in so it's displayed correctly.


https://github.com/SeattleColleges/nsc-events-nextjs/assets/33855430/5cd5afe9-6e69-43e0-84c8-dc3b63891bc3

