### PR TITLE
nsc-events-nextjs_7_continuous-deployment_add-ssh-workflow

### DIFF
--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -1,0 +1,51 @@
+name: Continuous Deployment through SSH.yml
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+  # Uncomment the following lines to enable automatic deployment on push to the main branch
+  # push:
+  #   branches:
+  #     - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install SSH Key
+        env:
+          DEPLOYUSERSSHKEY: ${{ secrets.DEPLOYUSERSSHKEY }}
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$DEPLOYUSERSSHKEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+      - name: Add SSH Key to SSH Agent
+        run: |
+          eval "$(ssh-agent -s)"
+          ssh-add ~/.ssh/id_rsa
+      - name: Execute Deployment Commands
+        run: |
+          ssh -o StrictHostKeyChecking=no deployuser@44.238.195.106 << 'EOF'
+            set -e # Exit immediately if a command exits with a non-zero status
+            source ~/.profile || true
+            source ~/.bashrc || true
+            # Ensure you're in the correct directory
+            cd ~/nextServer
+            # Fetch the latest changes
+            git pull origin main
+            # Activate the Node.js version managed by nvm
+            source ~/.nvm/nvm.sh
+            # Read the Node.js version from .nvmrc
+            NODE_VERSION=$(cat .nvmrc)
+            nvm install $NODE_VERSION
+            nvm use $NODE_VERSION
+            # Install any new dependencies using npm from nvm
+            npm install
+            # Build the project
+            npm run build
+            # Install and restart the application with PM2
+            npm install pm2 -g
+            pm2 restart nscEventsNextFrontend
+          EOF


### PR DESCRIPTION
resolves #416 

This workflow has been tested in [my fork](https://github.com/TuongPhamM/nsc-events-nextjs/actions/runs/9374797733).
Here is the run showing passed secret key, Node and Branch update.

https://github.com/SeattleColleges/nsc-events-nextjs/assets/77989401/fd0a13c5-84c7-419c-9d98-8b5757b1a834


