### PR TITLE
nsc-events-nextjs_8_433_add-and-update-eventMeetingUrl

### DIFF
--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -197,11 +197,11 @@ const CreateEvent: React.FC = () => {
             id="event-meeting-url"
             label="Event Meeting URL"
             variant="outlined"
-            name="eventMeetingUrl"
-            value={eventData.eventMeetingUrl}
+            name="eventMeetingURL"
+            value={eventData.eventMeetingURL}
             onChange={handleInputChange}
-            error={!!errors.eventMeetingUrl}
-            helperText={errors.eventMeetingUrl}
+            error={!!errors.eventMeetingURL}
+            helperText={errors.eventMeetingURL}
             InputProps={{ style: textFieldStyle.input }}
             InputLabelProps={{ style: textFieldStyle.label }}
           />

--- a/components/EditDialog.tsx
+++ b/components/EditDialog.tsx
@@ -154,11 +154,11 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
                                 id="event-meeting-url"
                                 label="Event Meeting URL"
                                 variant="outlined"
-                                name="eventMeetingUrl"
-                                value={eventData.eventMeetingUrl || ""}
+                                name="eventMeetingURL"
+                                value={eventData.eventMeetingURL || ""}
                                 onChange={handleInputChange}
-                                error={!!errors.eventMeetingUrl}
-                                helperText={errors.eventMeetingUrl}
+                                error={!!errors.eventMeetingURL}
+                                helperText={errors.eventMeetingURL}
                                 InputProps={{ style: textFieldStyle.input }}
                                 InputLabelProps={{ style: textFieldStyle.label }}
                             />

--- a/components/ViewMoreDetailsDialog.tsx
+++ b/components/ViewMoreDetailsDialog.tsx
@@ -43,7 +43,7 @@ function ViewMoreDetailsDialog({
 
   const moreDetails = [
     { title: "Host", detail: event.eventHost },
-    { title: "URL", detail: event.eventMeetingUrl },
+    { title: "URL", detail: event.eventMeetingURL },
     { title: "Registration", detail: event.eventRegistration },
     { title: "Tags", detail: arrayToString(event.eventTags) },
     { title: "Speakers", detail: arrayToString(event.eventSpeakers) },

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -16,7 +16,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     eventStartTime: "",
     eventEndTime: "",
     eventLocation: "",
-    eventMeetingUrl: "",
+    eventMeetingURL: "",
     eventCoverPhoto: "",
     eventHost: "",
     eventRegistration: "",
@@ -142,7 +142,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
 
     try {
       const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
-      const response = await fetch("${apiUrl}/events/new", {
+      const response = await fetch(`${apiUrl}/events/new`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/models/activity.ts
+++ b/models/activity.ts
@@ -8,7 +8,7 @@ export interface FormErrors {
     eventEndTime?: string;
     eventSchedule?: string;
     eventLocation?: string;
-    eventMeetingUrl?: string;
+    eventMeetingURL?: string;
     eventCoverPhoto?: string;
     eventHost?: string;
     eventRegistration?: string;
@@ -51,7 +51,7 @@ export interface Activity {
     eventStartTime: string;
     eventEndTime: string;
     eventLocation: string;
-    eventMeetingUrl: string;
+    eventMeetingURL: string;
     eventCoverPhoto: string;
     eventHost: string;
     eventRegistration: string;
@@ -77,7 +77,7 @@ export const activity: Activity = {
     eventStartTime: "",
     eventEndTime: "",
     eventLocation: "",
-    eventMeetingUrl: "",
+    eventMeetingURL: "",
     eventCoverPhoto: "",
     eventHost: "",
     eventRegistration: "",

--- a/models/activityAutofill.ts
+++ b/models/activityAutofill.ts
@@ -9,7 +9,7 @@ const activityAutofill: Activity = {
     eventStartTime: "10:00 AM",
     eventEndTime: "4:00 PM",
     eventLocation: "123 Main Street, City",
-    eventMeetingUrl: "https://zoom.us/sample-url",
+    eventMeetingURL: "https://zoom.us/sample-url",
     eventCoverPhoto: "https://example.com/event-cover.jpg",
     eventHost: "Sample Organization",
     eventRegistration: "Register at https://example.com/registration",

--- a/models/activityDatabase.ts
+++ b/models/activityDatabase.ts
@@ -27,7 +27,7 @@ export interface ActivityDatabase {
     attendanceCount: number;
     eventPrivacy: string;
     eventAccessibility: string;
-    eventMeetingUrl: string;
+    eventMeetingURL: string;
     eventNote: string;
     isHidden?: boolean;
     isArchived?: boolean;
@@ -43,6 +43,7 @@ export const activityDatabase: ActivityDatabase = {
     eventStartTime: "",
     eventEndTime: "",
     eventLocation: "",
+    eventMeetingURL: "",
     eventCoverPhoto: "",
     eventHost: "",
     eventRegistration: "",
@@ -62,6 +63,5 @@ export const activityDatabase: ActivityDatabase = {
     attendanceCount: 0,
     eventPrivacy: "",
     eventNote: "",
-    eventMeetingUrl: "",
     eventAccessibility: ""
 };


### PR DESCRIPTION
Resolves #433 

This PR adds the eventMeetingURL to the activityDatabase.ts file and updates the eventMeetingUrl to eventMeetingURL on all relevant pages so that it is consistent with the backend. This makes the URL no longer appear as undefined in the View More Details dialog when the More Details button is clicked on the Event Detail page (old events that were created through the frontend may still appear as undefined). You can test this by creating a new event.

<img width="633" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/560cd096-1b03-48de-b252-268135ccdd00">
