### PR TITLE
nsc-events-nextjs_8_428_event-background-images

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -22,6 +22,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
+import { Backdrop } from '@mui/material';
 import { useRouter } from "next/navigation";
 import AttendDialog from "@/components/AttendDialog";
 import ArchiveDialog from "@/components/ArchiveDialog";
@@ -196,7 +197,32 @@ const EventDetail = ({ searchParams }: SearchParams) => {
 
   return (
     <>
-      <Box className={styles.container}>
+      <Box className={styles.container}
+        sx={{
+          position: "relative",
+          zIndex: 0,
+          overflow: "hidden",
+          "&:before": {
+            content: "''",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundImage: `url(${event.eventCoverPhoto})`,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+            filter: "blur(8px)",
+            opacity: 0.3
+          }
+        }}
+      >
+        <Box className={styles.container}
+          sx={{ 
+            backgroundColor: "rgba(0, 0, 0, 0)",
+            zIndex: 1,
+          }}
+        >
         <Button onClick={getPrevEvent}>
           <ArrowBackIosIcon sx={{ color: 'white', fontSize: '100px' }} />
         </Button>
@@ -336,6 +362,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
         <Button onClick={getNextEvent}>
         <ArrowForwardIosIcon sx={{ color: 'white', fontSize: '100px' }} />
         </Button>
+      </Box>
       </Box>
     </>
   );

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -22,7 +22,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
-import { Backdrop } from '@mui/material';
 import { useRouter } from "next/navigation";
 import AttendDialog from "@/components/AttendDialog";
 import ArchiveDialog from "@/components/ArchiveDialog";


### PR DESCRIPTION
Resolves #428

This PR puts the event cover photo as the background image and blurs it/makes it transparent.

![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/add2cac0-0124-427f-9dab-1d129afa1678)
