### PR TITLE
nsc-events-8-bug-440-improper-event-loading

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -120,7 +120,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
   const { mutate: deleteEventMutation } = useMutation({
     mutationFn: deleteEvent,
      onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey:['myEvents', 'events'] });
+      await queryClient.refetchQueries({ queryKey:['events', 'myEvents', 'archivedEvents'] });
       setSnackbarMessage("Successfully deleted event.");
       setTimeout(() => {
         router.push("/");

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -44,7 +44,7 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
         mutationFn: archiveEvent,
         onSuccess: async () => {
             setSnackbarMessage("Successfully archived event.");
-            await queryClient.refetchQueries({ queryKey: ['events', 'myEvents'] });
+            await queryClient.refetchQueries({ queryKey: ['events', 'myEvents', 'archivedEvents'] });
             setTimeout( () => {
                 router.push("/");
             }, 1200);

--- a/hooks/useEditForm.tsx
+++ b/hooks/useEditForm.tsx
@@ -116,7 +116,7 @@ const to24HourTime  = (time: string) => {
   const { mutate: editEventMutation }  = useMutation({
     mutationFn: editEvent,
     onSuccess: async () => {
-      await queryClient.refetchQueries({queryKey:['myEvents', 'events']});
+      await queryClient.refetchQueries({queryKey:['events', 'myEvents', 'archivedEvents']});
       setSuccessMessage( "Event successfully updated!");
       setTimeout( () => {
         window.location.reload()

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -154,7 +154,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
       const data = await response.json();
       if (response.ok) {
         console.log("Activity created:", data);
-        await queryClient.refetchQueries({queryKey:['myEvents', 'events']});
+        await queryClient.refetchQueries({queryKey:['events', 'myEvents', 'archivedEvents']});
         setSuccessMessage(data.message || "Event  successfully created!");
         setErrorMessage("");
         // todo: navigate to a success page and clear form

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -29,7 +29,7 @@ const getArchivedEvents = async(page: any) => {
 }
 export function useArchivedEvents(page: any) {
     return useQuery<ActivityDatabase[], Error>({
-        queryKey: ["events", page],
+        queryKey: ["archivedEvents", page],
         queryFn: async () => getArchivedEvents(page),
     });
 }


### PR DESCRIPTION
Resolves
#440 

This PR updates the useArchivedEvents query to use the query key 'archivedEvents'. The 'archivedEvents' query key is also included in each refetchQueries array.

This will ensure the correct event list is returned for each query and fixes a bug where more than 5 events were already loaded when navigating to either the home page or archived events page if either page had been visited before.