### PR TITLE
nsc-events-nextjs_8_351_update-styling-of-confirmation-messages

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -360,7 +360,7 @@ const EventDetail = ({ searchParams }: SearchParams) => {
           autoHideDuration={1200}
           anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         >
-          <SnackbarContent message={snackbarMessage} sx={{ color: "black" }} />
+          <SnackbarContent message={snackbarMessage} sx={{ backgroundColor: "white", color: "black" }} />
         </Snackbar>
         <Button onClick={getNextEvent}>
         <ArrowForwardIosIcon sx={{ color: 'white', fontSize: '100px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -94,7 +94,7 @@ const ArchiveDialog = ({ isOpen, eventId, dialogToggle }: ArchiveDialogProps) =>
             >
                 <SnackbarContent
                     message={snackbarMessage}
-                    sx={{ color: 'black' }}
+                    sx={{ backgroundColor: "white", color: "black" }}
                 />
             </Snackbar>
         </>

--- a/components/AttendDialog.tsx
+++ b/components/AttendDialog.tsx
@@ -133,7 +133,7 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
             >
                 <SnackbarContent
                     message={snackbarMessage}
-                    sx={{ color: 'black' }}
+                    sx={{ backgroundColor: "white", color: "black" }}
                 />
             </Snackbar>
         </>


### PR DESCRIPTION
Resolves #451 

This PR changes the appearance of the confirmation messages from deleting/archiving/attending events so that it is readable.

Before:
<img width="500" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/1d78613d-251b-42c1-bd9f-af69773b3517">

After:
<img width="500" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/b027933f-1d09-446e-9320-bd18bd6de435">
