### PR TITLE
nsc-events-nextjs_8_453_refactor-text-border-to-be-visible

### DIFF
--- a/components/InputFields.tsx
+++ b/components/InputFields.tsx
@@ -5,14 +5,9 @@ import IconButton from '@mui/material/IconButton';
 
 export const textFieldStyle = {
   input: {
-    color: 'black', 
-    backgroundColor: 'white', 
-    '&::placeholder': {
-      color: 'black', 
-    },
+    fontSize: '1.1rem',
   },
   label: {
-    color: 'black', 
     fontSize: '1.1rem', 
   },
 };


### PR DESCRIPTION
Resolves #453 

This PR will fix the text color in the text field border to be visible as the screenshot below:

### Result:
Before:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/72054441/40ee0821-c2de-49dd-a57b-f8dc0e652aec)

After:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/72054441/3b1ed468-a42c-41a5-8f89-22ee44780a2c)
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/72054441/e0559ae5-82cd-4472-aad0-47699e904b40)


