### PR TITLE
nsc-events_nextjs _ 07 _ 416 _ continuous-deployment

### DIFF
--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -47,5 +47,5 @@ jobs:
             npm run build
             # Install and restart the application with PM2
             npm install pm2 -g
-            pm2 restart nscEventsNextFrontend
+            pm2 restart nsc_events_nextjs
           EOF

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "@mui/material";
 
 const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 
-// similar to sign-up page, but we're only handling email and password 
+// similar to sign-up page, but we're only handling email and password. 
 const Signin = () => {
   const { palette } = useTheme();
 


### PR DESCRIPTION
resolves #416

When I triggered the workflow, the error hinted to me that the pm2 instance was renamed which stopped SSH workflow from working. Here is a quick resolve. 

![Screenshot 2024-06-11 195928](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77989401/b7f0d1cc-b1a8-4af1-976d-071ef805549c)
