### PR TITLE
nsc-events-nextjs_8_392_change-password-sign-out

### DIFF
--- a/app/auth/change-password/page.tsx
+++ b/app/auth/change-password/page.tsx
@@ -104,6 +104,8 @@ const ChangePassword = () => {
           setSnackBarMessage(response.message);
           // Handle success
           if (response.status === "success") {
+            localStorage.removeItem('token');
+            window.dispatchEvent(new CustomEvent('auth-change'));
             setTimeout(() => {
               router.push("/auth/sign-in");
             }, 2000); // Navigate back to the sign-in page after 2 seconds

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -10,7 +10,6 @@ import white_vertical_nsc_logo from 'public/images/white_vertical_nsc_logo.png'
 import { useTheme } from "@mui/material";
 
 const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
-const URL =  "http://localhost:3000/api";
 
 // similar to sign-up page, but we're only handling email and password 
 const Signin = () => {

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -10,6 +10,7 @@ import white_vertical_nsc_logo from 'public/images/white_vertical_nsc_logo.png'
 import { useTheme } from "@mui/material";
 
 const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const URL =  "http://localhost:3000/api";
 
 // similar to sign-up page, but we're only handling email and password 
 const Signin = () => {


### PR DESCRIPTION
Resolves #392

This PR fixes the bug where the user successfully changing their password redirects them to the sign-in page, but they are still logged in. Now, changing your password should sign you out, so that you can log in with your new password.

Recreate the bug:
- While logged in, head to the Change Password page (auth/change-password)
- Enter previous password and new password and confirm
- You should be redirected to the Sign-in page, but in the Navbar, it shows "Sign out", proving that you are still signed in



Please ensure that you are signed in and enter the correct previous password. I'm unsure of why there are some people experiencing issues with it, but the change password functionality is outside of the changes of my PR; I only made it so that it logs out after the change is successful. 

https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/824663af-e9d5-4a5d-9a1e-863166f703bd
