### PR TITLE
nsc-events-nextjs_7_482_admin-role-authorization

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,10 +1,14 @@
+"use client";
 import Link from "next/link";
 import { Box, Button, Container } from '@mui/material';
 import { FC } from "react";
 import styles from "../home.module.css";
 import '../globals.css';
+import UnauthorizedPageMessage from "@/components/UnauthorizedPageMessage";
+import useAuth from "@/hooks/useAuth";
 
 const Admin = () => {
+    const { isAuth, user } = useAuth();
     interface AdminButtonProps {
         path: string;
         text: string;
@@ -20,22 +24,27 @@ const Admin = () => {
             </Button>
         )
     }
-  return (
-      <Container maxWidth={false} className="bg-solid">
-          <Box className={styles.title}
-              display="flex"
-              justifyContent="center"
-              alignContent="center"
-              height="100vh"
-          >
-              <AdminButton path={'/edit-user-role-page'} text={"Edit User Role"}/>
-              <AdminButton path={'/create-event'} text={"Create Event"}/>
-              <AdminButton path={'/my-events'} text={"View My Events"}/>
-              <AdminButton path={'/archived-events'} text={"View Archived Events"}/>
-              <AdminButton path={'/'} text={"View All Events"}/>
-          </Box>
-      </Container>
-  );
+
+    if (isAuth && (user?.role === 'admin')) {
+        return (
+            <Container maxWidth={false} className="bg-solid">
+                <Box className={styles.title}
+                    display="flex"
+                    justifyContent="center"
+                    alignContent="center"
+                    height="100vh"
+                >
+                    <AdminButton path={'/edit-user-role-page'} text={"Edit User Role"}/>
+                    <AdminButton path={'/create-event'} text={"Create Event"}/>
+                    <AdminButton path={'/my-events'} text={"View My Events"}/>
+                    <AdminButton path={'/archived-events'} text={"View Archived Events"}/>
+                    <AdminButton path={'/'} text={"View All Events"}/>
+                </Box>
+            </Container>
+        );
+    } else {
+        return <UnauthorizedPageMessage/>
+    }
 };
 
 export default Admin;

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from "react";
 import UserCard from "../../components/UserCard";
 import { Box, Stack, Typography } from "@mui/material";
+import useAuth from "@/hooks/useAuth";
+import UnauthorizedPageMessage from "@/components/UnauthorizedPageMessage";
 
 /**
  * Represents a user.
@@ -51,21 +53,27 @@ const EditUserRolePage = () => {
     fetchUser(setUserInfo);
   }, []);
 
-  return (
-    <Box sx={{ display: "flex", justifyContent: "center" }}>
-      <Stack alignItems="center">
-        <Typography
-            fontSize={"2.25rem"}
-            textAlign={"center"}
-            marginTop={"2rem"}
-        >User Management
-        </Typography>
-        {userInfo.map((user, index) => (
-          <UserCard user={user} key={index} />
-        ))}
-      </Stack>
-    </Box>
-  );
+  const { isAuth, user } = useAuth();
+
+  if (isAuth && (user?.role === 'admin')) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center" }}>
+        <Stack alignItems="center">
+          <Typography
+              fontSize={"2.25rem"}
+              textAlign={"center"}
+              marginTop={"2rem"}
+          >User Management
+          </Typography>
+          {userInfo.map((user, index) => (
+            <UserCard user={user} key={index} />
+          ))}
+        </Stack>
+      </Box>
+    );
+ } else {
+  return <UnauthorizedPageMessage/>
+  }
 };
 
 export default EditUserRolePage;

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ const createJestConfig = nextJest({
  
 // Add any custom config to be passed to Jest
 const config = {
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
   preset: 'ts-jest',

--- a/tests/unit/admin.test.tsx
+++ b/tests/unit/admin.test.tsx
@@ -1,12 +1,27 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import Page from '../../app/admin/page';
+import useAuth from '@/hooks/useAuth'
 
+
+jest.mock('@/hooks/useAuth', () => ({
+    __esModule: true,
+    default: jest.fn(),
+  }))
+  
 describe('Admin', () => {
+    beforeEach(() => {
+        (useAuth as jest.Mock).mockReturnValue({
+          isAuth: true,
+          user: { role: 'admin' }
+        })
+      })
+
     it('renders the buttons', () => {
         render(<Page />)
         const button = screen.getAllByRole('button')
         const buttonText = screen.getByText('Edit User Role')
-        expect(button && buttonText).toBeInTheDocument()
+        expect(button.length).toBeGreaterThan(0)
+        expect(buttonText).toBeInTheDocument()
     })
 })

--- a/tests/unit/admin.test.tsx
+++ b/tests/unit/admin.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react'
 import Page from '../../app/admin/page';
 import useAuth from '@/hooks/useAuth'
 
-
 jest.mock('@/hooks/useAuth', () => ({
     __esModule: true,
     default: jest.fn(),

--- a/tests/unit/editUserRole.test.tsx
+++ b/tests/unit/editUserRole.test.tsx
@@ -1,7 +1,14 @@
 // tests/unit/edit-user-role-page.test.tsx
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import EditUserRolePage from '../../app/edit-user-role-page/page'
+import useAuth from '@/hooks/useAuth'
+
+// Mock the useAuth hook
+jest.mock('@/hooks/useAuth', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
 
 // Mock the UserCard component
 jest.mock('../../components/UserCard', () => ({ user }: any) => (
@@ -28,14 +35,30 @@ describe('EditUserRolePage', () => {
     jest.restoreAllMocks()
   })
 
-  it('renders the page title', () => {
-    render(<EditUserRolePage />)
+  it('renders the page title', async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isAuth: true,
+      user: { role: 'admin' }
+    })
+
+    await act(async () => {
+      render(<EditUserRolePage />)
+    })
+
     const title = screen.getByText('User Management')
     expect(title).toBeInTheDocument()
   })
 
   it('fetches and displays user information', async () => {
-    render(<EditUserRolePage />)
+    // Mock the useAuth hook to return an authenticated admin user
+    (useAuth as jest.Mock).mockReturnValue({
+      isAuth: true,
+      user: { role: 'admin' }
+    })
+
+    await act(async () => {
+      render(<EditUserRolePage />)
+    })
 
     await waitFor(() => {
       const userCards = screen.getAllByTestId('user-card')


### PR DESCRIPTION
Resolves #482

This PR restricts access to the Admin page and Edit User Role page to admins. Attempting to go to these pages as a non-admin user/visitor will prompt a "401 Unauthorized" screen.

![Screenshot 2024-06-27 205235](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/5421d083-2f41-448d-9f4e-51849a72e2d4)
![Screenshot 2024-06-27 205845](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/8653ee12-88bd-442a-bcc7-5a69db1835b6)
