### PR TITLE
nsc-events-nextjs-9-495-redirect-to-event-after-creation

### DIFF
--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -4,9 +4,10 @@ import { Activity, FormErrors } from "@/models/activity";
 import useDateTimeSelection from "./useDateTimeSelection";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from 'next/navigation';
 
 export const useEventForm = (initialData: Activity | ActivityDatabase) => {
-
+  const router = useRouter();
   const [eventData, setEventData] = useState<Activity | ActivityDatabase>(initialData);
   const [errors, setErrors] = useState<FormErrors>({
     eventTitle: "",
@@ -158,7 +159,9 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
         await queryClient.refetchQueries({queryKey:['events', 'myEvents', 'archivedEvents']});
         setSuccessMessage(data.message || "Event  successfully created!");
         setErrorMessage("");
-        // todo: navigate to a success page and clear form
+        setTimeout(() => {
+          router.push(`/event-detail?id=${data.activity._id}`)
+        }, 1200);
       } else {
         console.log("Failed to create activity:", response.status);
         throw new Error(data.message || "Failed to create the event.");


### PR DESCRIPTION
Resolves #495 
* PR implements functionality that redirects user to event details page of the event they just created.


https://github.com/SeattleColleges/nsc-events-nextjs/assets/22021615/79424c11-912f-4781-a5e7-f66ce4c9bedd

