### PR TITLE
nsc-events-nextjs_9_493_change-user-details

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -5,17 +5,21 @@ import { Box, Button, Stack, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import CurrentUserCard from "@/components/CurrentUserCard";
 import { useRouter } from "next/navigation";
+import EditUserDetailsDialog, { User } from "@/components/EditUserDetailsDialog";
 
-interface User {
-    firstName: string;
-    lastName: string;
-    email: string;
-    pronouns: string
-}
+// interface User {
+//     firstName: string;
+//     lastName: string;
+//     email: string;
+//     pronouns: string
+// }
+
 const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+
 const Profile = () => {
     const [user, setUser] = useState<User>();
     const [token, setToken] = useState<string | null>();
+    const [openEditDialog, setOpenEditDialog] = useState(false);
     const router = useRouter();
     const getUserFromId = async (userId: string) => {
         const response = await fetch(`${URL}/users/find/${userId}`);
@@ -29,6 +33,18 @@ const Profile = () => {
         const userId = getCurrentUserId();
         getUserFromId(userId);
     },[]);
+
+    const handleEditClick = () => {
+        setOpenEditDialog(true);
+      };
+    
+      const handleCloseEditDialog = (updatedUser?: User) => {
+        setOpenEditDialog(false);
+        if (updatedUser) {
+          setUser(updatedUser);
+        }
+      };    
+
     if (token === null) {
         return (
             <Box sx={{ display: "flex", justifyContent: "center" }}>
@@ -45,6 +61,8 @@ const Profile = () => {
             </Typography>
         )
     }
+
+
     return (
         <Box sx={{ display: "flex", justifyContent: "center" }}>
             <Stack>
@@ -52,9 +70,13 @@ const Profile = () => {
                     Welcome, { user?.firstName }
                 </Typography>
                 <CurrentUserCard user={user}/>
+                <Button onClick={handleEditClick}>Edit</Button>
                 <Button onClick={ () => router.replace('/auth/change-password') }>
                     Change Password
                 </Button>
+                {openEditDialog && (
+                    <EditUserDetailsDialog open={openEditDialog} onClose={handleCloseEditDialog} user={user} />
+                )}
             </Stack>
         </Box>
     );

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -7,13 +7,6 @@ import CurrentUserCard from "@/components/CurrentUserCard";
 import { useRouter } from "next/navigation";
 import EditUserDetailsDialog, { User } from "@/components/EditUserDetailsDialog";
 
-// interface User {
-//     firstName: string;
-//     lastName: string;
-//     email: string;
-//     pronouns: string
-// }
-
 const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
 
 const Profile = () => {
@@ -61,7 +54,6 @@ const Profile = () => {
             </Typography>
         )
     }
-
 
     return (
         <Box sx={{ display: "flex", justifyContent: "center" }}>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -62,7 +62,7 @@ const Profile = () => {
                     Welcome, { user?.firstName }
                 </Typography>
                 <CurrentUserCard user={user}/>
-                <Button onClick={handleEditClick}>Edit</Button>
+                <Button onClick={handleEditClick} sx={{ mt: 2 }}>Edit Profile</Button>
                 <Button onClick={ () => router.replace('/auth/change-password') }>
                     Change Password
                 </Button>

--- a/components/CurrentUserCard.tsx
+++ b/components/CurrentUserCard.tsx
@@ -14,7 +14,7 @@ function CurrentUserCard({ user }: { user: CurrentUserCardProps }) {
   return (
     <Box
         sx={{
-            border: '1px solid black',
+            border: '1px solid #ccc',
             borderRadius: 1,
             padding: 2,
             display: 'flex',

--- a/components/CurrentUserCard.tsx
+++ b/components/CurrentUserCard.tsx
@@ -28,7 +28,10 @@ function CurrentUserCard({ user }: { user: CurrentUserCardProps }) {
         spacing={1}
       >
         <Typography variant="body1" gutterBottom>
-          Full Name: { user.firstName } { user.lastName }
+          First Name: { user.firstName }
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+          Last Name: { user.lastName }
         </Typography>
         <Typography variant="body1" gutterBottom>
             Email: { user.email }

--- a/components/EditUserDetailsDialog.tsx
+++ b/components/EditUserDetailsDialog.tsx
@@ -20,7 +20,6 @@ export interface User {
 const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onClose, user }) => {
   const [firstName, setFirstName] = useState(user.firstName);
   const [lastName, setLastName] = useState(user.lastName);
-  const [email, setEmail] = useState(user.email);
   const [pronouns, setPronouns] = useState(user.pronouns);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
@@ -29,7 +28,6 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
   useEffect(() => {
     setFirstName(user.firstName);
     setLastName(user.lastName);
-    setEmail(user.email);
     setPronouns(user.pronouns);
   }, [user]);
 
@@ -43,8 +41,9 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${token}`
         },
-        body: JSON.stringify({ firstName, lastName, email, pronouns })
+        body: JSON.stringify({ firstName, lastName, pronouns })
       });
+      console.log(response.body)
       if (response.ok) {
         const updatedUser = await response.json();
         onClose(updatedUser);
@@ -78,11 +77,6 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
               label="Last Name"
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
-            />
-            <TextField
-              label="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
             />
             <TextField
               label="Pronouns"

--- a/components/EditUserDetailsDialog.tsx
+++ b/components/EditUserDetailsDialog.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from "react";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box } from "@mui/material";
+import Snackbar from '@mui/material/Snackbar';
+import Alert, { AlertColor } from '@mui/material/Alert';
+
+interface EditUserDetailsDialogProps {
+  open: boolean;
+  onClose: (updatedUser?: User) => void;
+  user: User;
+}
+
+export interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  pronouns: string;
+}
+
+const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onClose, user }) => {
+  const [firstName, setFirstName] = useState(user.firstName);
+  const [lastName, setLastName] = useState(user.lastName);
+  const [email, setEmail] = useState(user.email);
+  const [pronouns, setPronouns] = useState(user.pronouns);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
+
+  useEffect(() => {
+    setFirstName(user.firstName);
+    setLastName(user.lastName);
+    setEmail(user.email);
+    setPronouns(user.pronouns);
+  }, [user]);
+
+  const handleSave = async () => {
+    const token = localStorage.getItem('token');
+    try {
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const response = await fetch(`${apiUrl}/users/update/${user.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ firstName, lastName, email, pronouns })
+      });
+      if (response.ok) {
+        const updatedUser = await response.json();
+        onClose(updatedUser);
+        setSnackbarSeverity('success');
+        setSnackbarMessage('Profile updated successfully!');
+      } else {
+        console.error('Failed to update profile:', response.statusText);
+        setSnackbarSeverity('error');
+        setSnackbarMessage('Failed to update profile');
+      }
+    } catch (error) {
+      console.error('Error updating profile:', error);
+      setSnackbarSeverity('error');
+      setSnackbarMessage('Error updating profile');
+    }
+    setSnackbarOpen(true);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={() => onClose()}>
+        <DialogTitle>Edit Profile</DialogTitle>
+        <DialogContent>
+          <Box display="flex" flexDirection="column" gap={2} mt={2}>
+            <TextField
+              label="First Name"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+            <TextField
+              label="Last Name"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+            <TextField
+              label="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <TextField
+              label="Pronouns"
+              value={pronouns}
+              onChange={(e) => setPronouns(e.target.value)}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => onClose()}>Cancel</Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={() => setSnackbarOpen(false)}>
+        <Alert onClose={() => setSnackbarOpen(false)} severity={snackbarSeverity} sx={{ width: '100%' }}>
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default EditUserDetailsDialog;

--- a/components/EditUserDetailsDialog.tsx
+++ b/components/EditUserDetailsDialog.tsx
@@ -21,6 +21,7 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
   const [firstName, setFirstName] = useState(user.firstName);
   const [lastName, setLastName] = useState(user.lastName);
   const [pronouns, setPronouns] = useState(user.pronouns);
+  const [isUpdated, setIsUpdated] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
@@ -29,7 +30,17 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
     setFirstName(user.firstName);
     setLastName(user.lastName);
     setPronouns(user.pronouns);
+    setIsUpdated(false);
   }, [user]);
+
+  const handleInputChange = (setter: React.Dispatch<React.SetStateAction<string>>, value: string, initialValue: string) => {
+    setter(value);
+    if (value !== initialValue) {
+      setIsUpdated(true);
+    } else {
+      setIsUpdated(false);
+    }
+  };
 
   const handleSave = async () => {
     const token = localStorage.getItem('token');
@@ -46,13 +57,15 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
       console.log(response.body)
       if (response.ok) {
         const updatedUser = await response.json();
-        onClose(updatedUser);
+        setTimeout(() => onClose(updatedUser), 1000);
         setSnackbarSeverity('success');
         setSnackbarMessage('Profile updated successfully!');
+        setSnackbarOpen(true);
       } else {
         console.error('Failed to update profile:', response.statusText);
         setSnackbarSeverity('error');
         setSnackbarMessage('Failed to update profile');
+        setSnackbarOpen(true);
       }
     } catch (error) {
       console.error('Error updating profile:', error);
@@ -71,26 +84,27 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
             <TextField
               label="First Name"
               value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
+              onChange={(e) => handleInputChange(setFirstName, e.target.value, user.firstName)}
             />
             <TextField
               label="Last Name"
               value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
+              onChange={(e) => handleInputChange(setLastName, e.target.value, user.lastName)}
             />
             <TextField
               label="Pronouns"
               value={pronouns}
-              onChange={(e) => setPronouns(e.target.value)}
+              onChange={(e) => handleInputChange(setPronouns, e.target.value, user.pronouns)}
             />
           </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => onClose()}>Cancel</Button>
-          <Button onClick={handleSave}>Save</Button>
+          <Button onClick={handleSave} disabled={!isUpdated}>Save</Button>
         </DialogActions>
       </Dialog>
-      <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={() => setSnackbarOpen(false)}>
+      <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
         <Alert onClose={() => setSnackbarOpen(false)} severity={snackbarSeverity} sx={{ width: '100%' }}>
           {snackbarMessage}
         </Alert>


### PR DESCRIPTION
Resolves #493 

This PR adds edit functionality to the profile page, allowing the user to change their first name, last name, and pronouns. A SnackBar message will signify success with updating the profile, but if no changes are made while the dialog is open, the "Save" button will be disabled. 

I tried to make the page more similar in appearance with the Edit User Role page to create more consistency between the pages.

https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/878e78c8-eb19-44c7-9fda-355190f87e45





