### PR TITLE
nsc-events-nextjs_9_502_disable-save-dialog-buttons

### DIFF
--- a/components/EditDialog.tsx
+++ b/components/EditDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import Dialog from "@mui/material/Dialog";
 import { DatePicker, LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
@@ -34,9 +34,21 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
         errorMessage
     } = useEditForm(event);
 
+    const [initialEventData, setInitialEventData] = useState(event);
+
     // Convert startTime and endTime from string to Date for TimePicker
     const startTimeDate = to24HourTime(eventData.eventStartTime);
     const endTimeDate = to24HourTime(eventData.eventEndTime)
+
+    useEffect(() => {
+        if (isOpen) {
+            setInitialEventData(event);
+        }
+    }, [isOpen, event]);
+
+    const isFormUpdated = () => {
+        return JSON.stringify(initialEventData) !== JSON.stringify(eventData);
+    };
 
     return (
         <>
@@ -365,7 +377,7 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
                             />
                             <Box sx={{ display: 'flex', justifyContent: 'space-between' }} >
                                 <Box>
-                                <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none" }}>
+                                <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none" }} disabled={!isFormUpdated()}>
                                     Confirm Edit
                                 </Button>
                                 <div className="error-messages">

--- a/components/EditDialog.tsx
+++ b/components/EditDialog.tsx
@@ -46,7 +46,7 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
         }
     }, [isOpen, event]);
 
-    const isFormUpdated = () => {
+    const isEventUpdated = () => {
         return JSON.stringify(initialEventData) !== JSON.stringify(eventData);
     };
 
@@ -377,7 +377,7 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
                             />
                             <Box sx={{ display: 'flex', justifyContent: 'space-between' }} >
                                 <Box>
-                                <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none" }} disabled={!isFormUpdated()}>
+                                <Button type="submit" variant="contained" color="primary" style={{ textTransform: "none" }} disabled={!isEventUpdated()}>
                                     Confirm Edit
                                 </Button>
                                 <div className="error-messages">

--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -25,11 +25,13 @@ interface ConfirmationDialogRawProps {
 export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
   const { onClose, value: valueProp, open, ...other } = props;
   const [value, setValue] = useState(valueProp);
+  const [roleUpdated, setRoleUpdated] = useState(false);
   const radioGroupRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (!open) {
       setValue(valueProp);
+      setRoleUpdated(false);
     }
   }, [valueProp, open]);
 
@@ -51,8 +53,18 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
     }
   };
 
+  // const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   setValue((event.target as HTMLInputElement).value);
+  // };
+
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue((event.target as HTMLInputElement).value);
+    const newValue = (event.target as HTMLInputElement).value;
+    setValue(newValue);
+    if (newValue !== valueProp) {
+      setRoleUpdated(true);
+    } else {
+      setRoleUpdated(false);
+    }
   };
 
   return (
@@ -86,7 +98,7 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
         <Button autoFocus onClick={handleCancel}>
           Cancel
         </Button>
-        <Button onClick={handleOk}>Ok</Button>
+        <Button onClick={handleOk} disabled={!roleUpdated}>Ok</Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
Resolves #502

This PR disables the "Ok" button in the Edit User Role dialog box and the "Confirm Edit" button in Edit Event dialog until a change is made, where it is enabled again.

What the disabled buttons look like because no change has been made in the dialogues:
![Screenshot 2024-07-04 050422](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/da34264e-5098-496a-a96e-899d4c873f62)

![Screenshot 2024-07-04 041047](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/3edf81ec-d74d-4b67-bbaf-8990b43eb46a)
