### PR TITLE
nsc-events-nextjs_9_501_url_errors_when_editing_event

### DIFF
--- a/utility/validateFormData.tsx
+++ b/utility/validateFormData.tsx
@@ -60,7 +60,7 @@ export const validateFormData = (data: Activity | ActivityDatabase): FormErrors 
     };
   }
   // todo: add more error validation rules
-  const urlPattern = /^(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:[/?].*)?$/;
+  const urlPattern = /^(http(s)?:\/\/){0,1}(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:[/?].*)?$/;
   if (!data.eventCoverPhoto || !urlPattern.test(data.eventCoverPhoto)) {
       newErrors = { ...newErrors, eventCoverPhoto: "Event cover photo needs to be a valid URL"  };
   }


### PR DESCRIPTION
Resolves #501

Previously, when creating events the page would throw an error if the user entered a valid URL with a protocol (https/http). This fix should now allow users to have protocols in their URLs when entering them in the correct fields (Event Cover Photo, Event Meeting URL)

https://github.com/SeattleColleges/nsc-events-nextjs/assets/60593178/d799e49d-e286-4e83-bd40-d9990336f798

