### PR TITLE
nsc-events-nextjs_9_509-responsive-ui-for-event-detail-page

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -271,7 +271,7 @@ const EventDetail = () => {
         >
         <Box
           className={styles.formContainer}
-          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: 2, backgroundColor: isMobile ? "" : containerColor  }}
+          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "105vh", marginTop: 2, backgroundColor: isMobile ? "" : containerColor  }}
         >
           <Card sx={{ width: isMobile ? "41vh" : "50vh", maxHeight: '100vh', overflowY: 'auto', mt: isMobile ? 5 : "", marginBottom: 3 }}>
             <CardMedia
@@ -309,7 +309,7 @@ const EventDetail = () => {
                 alignItems: "center",
                 flexDirection: isMobile ? "column" : "row",
                 gap: 2,
-                mt: 2,
+                mt: 2
               }}
             >
               <Grid container spacing={2} justifyContent="center" alignItems="center">

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -9,6 +9,8 @@ import {
   Box,
   Button,
   SnackbarContent,
+  useMediaQuery,
+  Grid,
 } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { activityDatabase, ActivityDatabase } from "@/models/activityDatabase";
@@ -17,6 +19,7 @@ import styles from "@/app/home.module.css";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ArchiveIcon from "@mui/icons-material/Archive";
+import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -31,6 +34,7 @@ import ViewMoreDetailsDialog from "@/components/ViewMoreDetailsDialog";
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { useTheme } from "@mui/material";
+import theme from "../theme";
 
 interface SearchParams {
   searchParams: {
@@ -57,6 +61,8 @@ const EventDetail = () => {
   const [userRole, setUserRole] = useState("");
   const { palette } = useTheme();
   const containerColor = palette.mode === "dark" ? "#333" : "#fff";
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
 
   const DeleteDialog = () => {
     return (
@@ -249,7 +255,7 @@ const EventDetail = () => {
             left: 0,
             right: 0,
             bottom: 0,
-            backgroundImage: `url(${event.eventCoverPhoto})`,
+            backgroundImage: isMobile ? "" : `url(${event.eventCoverPhoto})`,
             backgroundSize: "cover",
             backgroundPosition: "center",
             filter: "blur(8px)",
@@ -263,16 +269,11 @@ const EventDetail = () => {
             zIndex: 1,
           }}
         >
-          {events.length > 1 && events.findIndex(e => e._id === event._id) > 0 && (
-            <Button onClick={getPrevEvent}>
-              <ArrowBackIosIcon sx={{ color: 'white', fontSize: '100px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />
-            </Button>
-          )}
         <Box
           className={styles.formContainer}
-          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: "10vh", backgroundColor: containerColor  }}
+          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: "10vh", backgroundColor: isMobile ? "" : containerColor  }}
         >
-          <Card sx={{ width: "45vh", minHeight: "59vh", maxHeight: "100vh", marginBottom: "5vh" }}>
+          <Card sx={{ width: isMobile ? "40vh" : "45vh", minHeight: "59vh", maxHeight: "100vh", mt: isMobile ? "10vh" : "", marginBottom: "5vh" }}>
             <CardMedia
               component="img"
               image={event.eventCoverPhoto}
@@ -300,54 +301,68 @@ const EventDetail = () => {
               </Typography>
             </CardContent>
           </Card>
-          <div style={{ width: "100vh", display: "flex" }}>
-            <div
-              style={{
+          <Grid container spacing={2} justifyContent="center" alignItems="center">
+            <Box
+              sx={{
                 display: "flex",
-                width: "100vh",
-                gap: "25px",
-                padding: 20,
                 justifyContent: "center",
                 alignItems: "center",
+                flexDirection: isMobile ? "column" : "row",
+                gap: 2,
+                mt: 2,
               }}
             >
               {(userRole === "admin" ||
                 (userRole === "creator" && event?.createdByUser === userId)) && (
                 <>
-                  <Button
-                    variant="contained"
-                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
-                    onClick={() => {
-                      toggleEditDialog();
-                    }}
-                  >
-                    {" "}
-                    <EditIcon sx={{ marginRight: "5px" }} /> Edit{" "}
-                  </Button>
-                  <Button
-                    variant="contained"
-                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
-                    onClick={() => setDialogOpen(true)}
-                  >
-                    {" "}
-                    <DeleteIcon sx={{ marginRight: "5px" }} /> Delete{" "}
-                  </Button>
-                  <Button
-                    variant="contained"
-                    sx={{ color: "white", backgroundColor: "#2074d4", width: "125px" }}
-                    onClick={() => toggleArchiveDialog()}
-                  >
-                    {" "}
-                    <ArchiveIcon sx={{ marginRight: "5px" }} /> { !event.isArchived ? "Archive" : "Unarchive" }{" "}
-                  </Button>
+                  <Grid item xs={12} sm="auto">
+                    <Button
+                      variant="contained"
+                      sx={{ color: "white", backgroundColor: "#2074d4", ml: isMobile ? 0 : 2 }}
+                      onClick={toggleEditDialog}
+                    >
+                      <EditIcon sx={{ marginRight: isMobile ? 0 : "5px" }} />
+                      {!isMobile && !isTablet && "Edit"}
+                    </Button>
+                  </Grid>
+                  <Grid item xs={12} sm="auto">
+                    <Button
+                      variant="contained"
+                      sx={{ color: "white", backgroundColor: "#2074d4" }}
+                      onClick={() => setDialogOpen(true)}
+                    >
+                      <DeleteIcon sx={{ marginRight: isMobile ? 0 : "5px" }} />
+                      {!isMobile && !isTablet && "Delete"}
+                    </Button>
+                  </Grid>
+                  <Grid item xs={12} sm="auto">
+                    <Button
+                      variant="contained"
+                      sx={{ color: "white", backgroundColor: "#2074d4" }}
+                      onClick={toggleArchiveDialog}
+                    >
+                      {!event.isArchived ? (
+                        <>
+                          <ArchiveIcon sx={{ marginRight: isMobile ? 0 : "5px" }} />
+                          {!isMobile && !isTablet && "Archive"}
+                        </>
+                      ) : (
+                        <>
+                          <UnarchiveIcon sx={{ marginRight: isMobile ? 0 : "5px" }} />
+                          {!isMobile && !isTablet && "Unarchive"}
+                        </>
+                      )}
+                    </Button>
+                  </Grid>
                 </>
               )}
+              <Grid item xs={12} sm="auto">
               <Button
                     variant="contained"
                     sx={{
                       color: "white",
                       backgroundColor: "#2074d4",
-                      width: "140px",
+                      width: isMobile ? "175px" : "140px",
                     }}
                     onClick={() => {
                       toggleViewMoreDetailsDialog();
@@ -356,22 +371,48 @@ const EventDetail = () => {
                     {" "}
                     More Details{" "}
                   </Button>
-                  <Button
-                    variant="contained"
-                    sx={{
-                      color: "white",
-                      backgroundColor: "#2074d4",
-                      width: "125px",
-                    }}
-                    onClick={() => {
-                      toggleAttendDialog();
-                    }}
-                  >
-                    {" "}
-                    Attend{" "}
-                  </Button>
-            </div>
-          </div>
+                  </Grid>
+                  <Grid item xs={12} sm="auto">
+                    <Button
+                      variant="contained"
+                      sx={{
+                        color: "white",
+                        backgroundColor: "#2074d4",
+                        width: isMobile ? "175px" : "90px",
+                      }}
+                      onClick={() => {
+                        toggleAttendDialog();
+                      }}
+                    >
+                      {" "}
+                      Attend{" "}
+                    </Button>
+                  </Grid>
+            </Box>
+            <Box
+              sx={{
+                position: "absolute",
+                display: "flex",
+                justifyContent: events.length > 1 && events.findIndex(e => e._id === event._id) > 0 ? "space-between" : "end",
+                width: "100%",
+                maxWidth: 700,
+                top: "50%",
+                transform: "translateY(-50%)",
+                px: 2
+              }}
+            >
+            {events.length > 1 && events.findIndex(e => e._id === event._id) > 0 && (
+            <Button onClick={getPrevEvent}>
+              <ArrowBackIosIcon sx={{ fontSize: '60px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />
+            </Button>
+            )}
+            {events.length > 1 && events.findIndex(e => e._id === event._id) < events.length - 1 &&  (
+            <Button onClick={getNextEvent}>
+              <ArrowForwardIosIcon sx={{ fontSize: '60px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />
+            </Button>
+            )}
+          </Box>
+          </Grid>
         </Box>
         <DeleteDialog />
         <ViewMoreDetailsDialog
@@ -401,11 +442,6 @@ const EventDetail = () => {
         >
           <SnackbarContent message={snackbarMessage} sx={{ backgroundColor: "white", color: "black" }} />
         </Snackbar>
-        {events.length > 1 && events.findIndex(e => e._id === event._id) < events.length - 1 &&  (
-          <Button onClick={getNextEvent}>
-            <ArrowForwardIosIcon sx={{ color: 'white', fontSize: '100px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />
-          </Button>
-        )}
       </Box>
       </Box>
     </>

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -31,8 +31,8 @@ import ArchiveDialog from "@/components/ArchiveDialog";
 import EditDialog from "@/components/EditDialog";
 import { formatDate } from "@/utility/dateUtils";
 import ViewMoreDetailsDialog from "@/components/ViewMoreDetailsDialog";
-import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
+import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import { useTheme } from "@mui/material";
 import theme from "../theme";
 
@@ -312,10 +312,11 @@ const EventDetail = () => {
                 mt: 2,
               }}
             >
+              <Grid container spacing={2} justifyContent="center" alignItems="center">
               {(userRole === "admin" ||
                 (userRole === "creator" && event?.createdByUser === userId)) && (
                 <>
-                  <Grid item xs={12} sm="auto">
+                  <Grid item xs={4} sm="auto">
                     <Button
                       variant="contained"
                       sx={{ color: "white", backgroundColor: "#2074d4", ml: isMobile ? 0 : 2 }}
@@ -325,7 +326,7 @@ const EventDetail = () => {
                       {!isMobile && !isTablet && "Edit"}
                     </Button>
                   </Grid>
-                  <Grid item xs={12} sm="auto">
+                  <Grid item xs={4} sm="auto">
                     <Button
                       variant="contained"
                       sx={{ color: "white", backgroundColor: "#2074d4" }}
@@ -335,7 +336,7 @@ const EventDetail = () => {
                       {!isMobile && !isTablet && "Delete"}
                     </Button>
                   </Grid>
-                  <Grid item xs={12} sm="auto">
+                  <Grid item xs={4} sm="auto">
                     <Button
                       variant="contained"
                       sx={{ color: "white", backgroundColor: "#2074d4" }}
@@ -356,6 +357,7 @@ const EventDetail = () => {
                   </Grid>
                 </>
               )}
+              </Grid>
               <Grid item xs={12} sm="auto">
               <Button
                     variant="contained"
@@ -394,21 +396,22 @@ const EventDetail = () => {
                 position: "absolute",
                 display: "flex",
                 justifyContent: events.length > 1 && events.findIndex(e => e._id === event._id) > 0 ? "space-between" : "end",
+                alignContent: "center",
                 width: "100%",
                 maxWidth: 700,
-                top: "50%",
+                top: isMobile ? "34%" : "50%",
                 transform: "translateY(-50%)",
-                px: 2
+                px: 1
               }}
             >
             {events.length > 1 && events.findIndex(e => e._id === event._id) > 0 && (
-            <Button onClick={getPrevEvent}>
-              <ArrowBackIosIcon sx={{ fontSize: '60px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />
+            <Button onClick={getPrevEvent} sx={{ backgroundColor: isMobile ? "white" : "", color: isMobile ? "grey" : "", filter: isMobile ? "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" : "", ml: 0 }}>
+              <ArrowLeftIcon sx={{ fontSize: isMobile ? "40px" : "70px", filter:  isMobile ? "" : "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" }} />
             </Button>
             )}
             {events.length > 1 && events.findIndex(e => e._id === event._id) < events.length - 1 &&  (
-            <Button onClick={getNextEvent}>
-              <ArrowForwardIosIcon sx={{ fontSize: '60px', filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))' }} />
+            <Button onClick={getNextEvent} sx={{ backgroundColor: isMobile ? "white" : "", color: isMobile ? "grey" : "", filter: isMobile ? "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" : "", mr: -2 }}>
+              <ArrowRightIcon sx={{ fontSize: isMobile ? "40px" : "70px", filter: isMobile ? "" : "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" }} />
             </Button>
             )}
           </Box>

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -273,7 +273,7 @@ const EventDetail = () => {
           className={styles.formContainer}
           sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: 2, backgroundColor: isMobile ? "" : containerColor  }}
         >
-          <Card sx={{ width: isMobile ? "41vh" : "50vh", minHeight: "59vh", maxHeight: "100vh", mt: isMobile ? 6 : "", marginBottom: 3 }}>
+          <Card sx={{ width: isMobile ? "41vh" : "50vh", maxHeight: '100vh', overflowY: 'auto', mt: isMobile ? 5 : "", marginBottom: 3 }}>
             <CardMedia
               component="img"
               image={event.eventCoverPhoto}
@@ -284,7 +284,7 @@ const EventDetail = () => {
               <Typography gutterBottom variant="h5" component="div">
                 {event.eventTitle}
               </Typography>
-              <Typography variant="body2" color="text.secondary">
+              <Typography variant="body2" color="text.secondary" sx={{ pb: 1 }}>
                 {event.eventDescription}
               </Typography>
               <Typography variant="body2" color="text.secondary">

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -271,9 +271,9 @@ const EventDetail = () => {
         >
         <Box
           className={styles.formContainer}
-          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: "10vh", backgroundColor: isMobile ? "" : containerColor  }}
+          sx={{ minHeight: "69vh", maxHeight: "100vh", width: "100vh", marginTop: 2, backgroundColor: isMobile ? "" : containerColor  }}
         >
-          <Card sx={{ width: isMobile ? "40vh" : "45vh", minHeight: "59vh", maxHeight: "100vh", mt: isMobile ? "10vh" : "", marginBottom: "5vh" }}>
+          <Card sx={{ width: isMobile ? "41vh" : "50vh", minHeight: "59vh", maxHeight: "100vh", mt: isMobile ? 6 : "", marginBottom: 3 }}>
             <CardMedia
               component="img"
               image={event.eventCoverPhoto}
@@ -364,7 +364,8 @@ const EventDetail = () => {
                     sx={{
                       color: "white",
                       backgroundColor: "#2074d4",
-                      width: isMobile ? "175px" : "140px",
+                      width: "140px",
+                      mt: isMobile ? 1 : 0
                     }}
                     onClick={() => {
                       toggleViewMoreDetailsDialog();
@@ -380,7 +381,7 @@ const EventDetail = () => {
                       sx={{
                         color: "white",
                         backgroundColor: "#2074d4",
-                        width: isMobile ? "175px" : "90px",
+                        width: isMobile ? "140px" : "90px",
                       }}
                       onClick={() => {
                         toggleAttendDialog();
@@ -399,19 +400,18 @@ const EventDetail = () => {
                 alignContent: "center",
                 width: "100%",
                 maxWidth: 700,
-                top: isMobile ? "34%" : "50%",
+                top: isMobile ? "35%" : "43%",
                 transform: "translateY(-50%)",
-                px: 1
               }}
             >
             {events.length > 1 && events.findIndex(e => e._id === event._id) > 0 && (
-            <Button onClick={getPrevEvent} sx={{ backgroundColor: isMobile ? "white" : "", color: isMobile ? "grey" : "", filter: isMobile ? "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" : "", ml: 0 }}>
-              <ArrowLeftIcon sx={{ fontSize: isMobile ? "40px" : "70px", filter:  isMobile ? "" : "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" }} />
+            <Button onClick={getPrevEvent} sx={{ filter: isMobile ? "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" : "", p: 0, ml: 0 }}>
+              <ArrowLeftIcon sx={{ fontSize: isMobile ? "40px" : "70px", backgroundColor: isMobile ? "white" : "", color: isMobile ? "grey" : "", filter:  isMobile ? "" : "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))", borderRadius: "2px" }} />
             </Button>
             )}
             {events.length > 1 && events.findIndex(e => e._id === event._id) < events.length - 1 &&  (
-            <Button onClick={getNextEvent} sx={{ backgroundColor: isMobile ? "white" : "", color: isMobile ? "grey" : "", filter: isMobile ? "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" : "", mr: -2 }}>
-              <ArrowRightIcon sx={{ fontSize: isMobile ? "40px" : "70px", filter: isMobile ? "" : "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" }} />
+            <Button onClick={getNextEvent} sx={{ filter: isMobile ? "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))" : "", p: 0, mr: -2 }}>
+              <ArrowRightIcon sx={{ fontSize: isMobile ? "40px" : "70px", backgroundColor: isMobile ? "white" : "", color: isMobile ? "grey" : "", filter:  isMobile ? "" : "drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.2))", borderRadius: "2px" }} />
             </Button>
             )}
           </Box>


### PR DESCRIPTION
Resolves #509

This PR implements responsive design for the Event Detail page (up to the smallest mobile screen, which is 320 px). There was a lot that need to be adjusted with the structure of the page, buttons, and the arrow icons. I also enabled scrolling in the event card, which is useful for events with longer descriptions, and other fields.

Event Detail page on a desktop/laptop screen:
<img width="750" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/53e70d68-bf91-4905-8df7-31d07d3dd02a">

Event Detail page on a tablet screen (768 px width, using dev tools):
<img width="425" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/5b94f455-eb00-44d6-ada5-ccad2d1f8df3">

Event Detail page on a mobile screen (375 px width, using dev tools):
<img width="225" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/0ddb5bd8-bcad-4d5d-84ec-19d4bd3de0f6">


