### PR TITLE
nsc-events-nextjs_9_513_sign-up-responsive-ui

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -135,7 +135,7 @@ const SignUp = () => {
         alignItems: "center",
         height: "100vh",
         justifyContent: "center",
-        mt: isMobile ? 2 : isTablet ? 6 : 0,
+        mt: isMobile ? 4 : isTablet ? 8 : 2,
         width: isMobile ? '95%' : 'auto', 
       }}
     >

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Typography,
   Link as MuiLink,
+  useMediaQuery,
 } from "@mui/material";
 import { textFieldStyle } from "@/components/InputFields"
 import Snackbar, { SnackbarOrigin } from "@mui/material/Snackbar";
@@ -29,6 +30,9 @@ interface State extends SnackbarOrigin {
 
 const SignUp = () => {
   const { palette } = useTheme();
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const darkImagePath = white_vertical_nsc_logo;
   const lightImagePath = blue_vertical_nsc_logo;
@@ -130,6 +134,8 @@ const SignUp = () => {
         alignItems: "center",
         height: "100vh",
         justifyContent: "center",
+        mt: isMobile ? 15 : 10,
+        width: isMobile ? '90%' : 'auto', 
       }}
     >
       <Paper

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -33,6 +33,7 @@ const SignUp = () => {
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
   const darkImagePath = white_vertical_nsc_logo;
   const lightImagePath = blue_vertical_nsc_logo;
@@ -134,8 +135,8 @@ const SignUp = () => {
         alignItems: "center",
         height: "100vh",
         justifyContent: "center",
-        mt: isMobile ? 15 : 10,
-        width: isMobile ? '90%' : 'auto', 
+        mt: isMobile ? 2 : isTablet ? 6 : 0,
+        width: isMobile ? '95%' : 'auto', 
       }}
     >
       <Paper
@@ -166,7 +167,7 @@ const SignUp = () => {
           </Typography>
           <TextField
             fullWidth
-            margin="normal"
+            margin={isMobile ? "dense" : "normal"}
             label="First Name"
             name="firstName"
             value={userInfo.firstName}
@@ -178,7 +179,7 @@ const SignUp = () => {
           />
           <TextField
             fullWidth
-            margin="normal"
+            margin={isMobile ? "dense" : "normal"}
             label="Last Name"
             name="lastName"
             value={lastName}
@@ -190,7 +191,7 @@ const SignUp = () => {
           />
           <TextField
             fullWidth
-            margin="normal"
+            margin={isMobile ? "dense" : "normal"}
             label="Pronouns"
             name="pronouns"
             value={pronouns}
@@ -202,7 +203,7 @@ const SignUp = () => {
           />
           <TextField
             fullWidth
-            margin="normal"
+            margin={isMobile ? "dense" : "normal"}
             label="Email"
             name="email"
             value={email}
@@ -214,7 +215,7 @@ const SignUp = () => {
           />
           <TextField
             fullWidth
-            margin="normal"
+            margin={isMobile ? "dense" : "normal"}
             label="Password"
             name="password"
             value={password}
@@ -239,7 +240,7 @@ const SignUp = () => {
           />
           <TextField
             fullWidth
-            margin="normal"
+            margin={isMobile ? "dense" : "normal"}
             label="Confirm Password"
             name="confirmPassword"
             value={confirmPassword}


### PR DESCRIPTION
Resolves #513

This PR ensures that the Sign Up page has responsive UI and adjusts to mobile screen sizes (and tablet screens) well, with no cutoffs or the need to scroll horizontally. I made additional UI changes to the page in the desktop screen size as well to make sure the Sign Up page main element wasn't cut off at the top of the screen.

Test this PR by right clicking the page and using Inspect elements to enter the Toggle Device Toolbar and adjust the screen sizes.

Smallest mobile screen size:
![Screenshot 2024-07-07 174417](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/20c5dfb2-e2b6-4a27-8864-31abbdfbf4c3)

Tablet screen size:
![Screenshot 2024-07-07 174537](https://github.com/SeattleColleges/nsc-events-nextjs/assets/77607212/0642af7a-d0ba-4077-b6d3-1ae3938e0299)
