### PR TITLE
nsc-events-nextjs_9_515_refactor-event-description-field

### DIFF
--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -7,11 +7,12 @@ import { LocalizationProvider, TimePicker, DatePicker } from '@mui/x-date-picker
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { format, parse } from 'date-fns';
-import { Box, Button, Typography, Stack }  from '@mui/material';
+import { Box, Button, Typography, Stack, useTheme, useMediaQuery }  from '@mui/material';
 import { textFieldStyle } from "@/components/InputFields"
 import { MouseEvent, ChangeEvent, useState, FormEvent } from "react";
 import useAuth from "@/hooks/useAuth";
 import UnauthorizedPageMessage from "@/components/UnauthorizedPageMessage";
+import theme from "../theme";
 
 const CreateEvent: React.FC = () => {
   const {
@@ -35,6 +36,7 @@ const CreateEvent: React.FC = () => {
     // Convert startTime and endTime from string to Date for TimePicker
     const startTimeDate = startTime ? parse(startTime, 'HH:mm', new Date()) : null;
     const endTimeDate = endTime ? parse(endTime, 'HH:mm', new Date()) : null;
+    const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
 
     const handleDateChange = (newDate: Date | null) => {
       setSelectedDate(newDate);
@@ -73,7 +75,7 @@ const CreateEvent: React.FC = () => {
     if (isAuth && (user?.role === 'admin' || user?.role === 'creator')) {
       return (
         <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3, width: '75%', mx: 'auto' }}>
+          <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3, width: isMobile ? '100%' : '75%', mx: 'auto' }}>
           <Typography
               fontSize={"2.25rem"}
               textAlign={"center"}

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -98,6 +98,8 @@ const CreateEvent: React.FC = () => {
               <TextField
                 id="event-description"
                 label="Event Description"
+                multiline
+                maxRows={3}
                 variant="outlined"
                 name="eventDescription"
                 value={eventData.eventDescription}
@@ -105,6 +107,7 @@ const CreateEvent: React.FC = () => {
                 error={!!errors.eventDescription}
                 helperText={errors.eventDescription}
                 InputProps={{ style: textFieldStyle.input }}
+                inputProps={{ maxLength: 300 }}
                 InputLabelProps={{ style: textFieldStyle.label }}
                 placeholder="Enter the description of the event"
               />

--- a/components/EditDialog.tsx
+++ b/components/EditDialog.tsx
@@ -75,6 +75,8 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
                             <TextField
                                 id="event-description"
                                 label="Event Description"
+                                multiline
+                                maxRows={3}
                                 variant="outlined"
                                 name="eventDescription"
                                 value={eventData.eventDescription || ""}
@@ -82,6 +84,7 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
                                 error={!!errors.eventDescription}
                                 helperText={errors.eventDescription}
                                 InputProps={{ style: textFieldStyle.input }}
+                                inputProps={{ maxLength: 300 }}
                                 InputLabelProps={{ style: textFieldStyle.label }}
                                 placeholder="Enter the description of the event"
                             />


### PR DESCRIPTION
Resolves #515

To prevent disrupting the UI, this PR sets a 300-character limit for the event description when a user is creating or editing an event. To make the event description field easier to read and navigate, I changed it to be multi-line, instead of single-line. I also widened the fields on the Create Event page for mobile screens.
Creating event:
<img width="500" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/95e41670-cbb6-4219-af89-137f3dc3a979">
On a mobile screen:
<img width="200" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/1c44edc3-8ef4-479a-a562-74ccb191c4d7">

Editing event:
<img width="500" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/565185f8-1bdd-43ab-81a0-9de1601f11b4">
On a mobile screen:
<img width="275" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/35143116-36f4-4211-a71f-1b579bc6490c">

Long descriptions on a mobile screen:

https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/0061dac8-67bc-45fe-b8e1-1282290ce2b4




