### PR TITLE
nsc-events-nextjs-9-510-make-sign-up-consistent

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Typography,
   Link as MuiLink,
+  SnackbarContent,
 } from "@mui/material";
 import { textFieldStyle } from "@/components/InputFields"
 import Snackbar, { SnackbarOrigin } from "@mui/material/Snackbar";
@@ -279,7 +280,9 @@ const SignUp = () => {
         onClose={() => setSnackBarMessage("")}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         message={snackBarMessage}
-      />
+      >
+        <SnackbarContent message={snackBarMessage} sx={{ backgroundColor: "white", color: "black" }} />
+      </Snackbar>
     </Container>
   );
 };

--- a/utility/validateFormData.tsx
+++ b/utility/validateFormData.tsx
@@ -60,7 +60,7 @@ export const validateFormData = (data: Activity | ActivityDatabase): FormErrors 
     };
   }
   // todo: add more error validation rules
-  const urlPattern = /^(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:[/?].*)?$/;
+  const urlPattern = /^(http(s)?:\/\/){0,1}(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:[/?].*)?$/;
   if (!data.eventCoverPhoto || !urlPattern.test(data.eventCoverPhoto)) {
       newErrors = { ...newErrors, eventCoverPhoto: "Event cover photo needs to be a valid URL"  };
   }


### PR DESCRIPTION
Resolves #510 
Before:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/60593178/fee62330-014a-4a58-aae4-e8e564c8e1f3)

After:
![image](https://github.com/SeattleColleges/nsc-events-nextjs/assets/60593178/a6169407-9aea-410d-9724-c5b78d83800f)

Makes sign up confirmation message styling consistent with other confirmation messages across the website.