### PR TITLE
nsc-events-9-bug-518-invalid-start-and-end-times

### DIFF
--- a/components/EditDialog.tsx
+++ b/components/EditDialog.tsx
@@ -36,9 +36,12 @@ const EditDialog = ({ isOpen, event, toggleEditDialog }: EditDialogProps) => {
 
     const [initialEventData, setInitialEventData] = useState(event);
 
+    const RemoveWhitespace = (str: string) => str.replace(/\s+/g, '');
+    const trimmedEventStartTime = RemoveWhitespace(eventData.eventStartTime);
+    const trimmedEventEndTime = RemoveWhitespace(eventData.eventEndTime);
     // Convert startTime and endTime from string to Date for TimePicker
-    const startTimeDate = to24HourTime(eventData.eventStartTime);
-    const endTimeDate = to24HourTime(eventData.eventEndTime)
+    const startTimeDate = to24HourTime(trimmedEventStartTime);
+    const endTimeDate = to24HourTime(trimmedEventEndTime);
 
     useEffect(() => {
         if (isOpen) {


### PR DESCRIPTION
resolves #518 

This PR fixes the start and end time picker fields error. Events whose start and end times are formatted with a space between the time value and the time of day are not parsed properly and so the times must be formatted as such: "XX:XXAM" or "XX:XXPM"
"10:00 AM" -> "10:00AM"

The function I used to remove the whitespace uses a common regex pattern for removing whitespace.

https://github.com/SeattleColleges/nsc-events-nextjs/assets/13278479/172bb87d-585a-4a7e-8482-bfea84779fe0
