### PR TITLE
nsc-events-nextjs_9_526_improve-ui-and-add-headings

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { Box, Button, Container, Grid, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Button, Container, Grid, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { FC } from "react";
 import styles from "../home.module.css";
 import '../globals.css';
@@ -32,11 +32,18 @@ const Admin = () => {
     if (isAuth && (user?.role === 'admin')) {
         return (
             <Container maxWidth={false} className="bg-solid">
+                <Typography
+                    fontSize={isMobile ? "1.75rem" : "2.25rem"}
+                    textAlign={"center"}
+                    padding={"1rem"}
+                    marginTop={"1rem"}
+                    marginBottom={"1rem"}
+                >My Account</Typography>
                 <Box className={styles.title}
                     display="flex"
                     justifyContent="center"
                     alignContent="center"
-                    height="100vh"
+                    height="60vh"
                     flexDirection="column"
                 >
                     <Grid container spacing={2} justifyContent="center" alignItems="center">

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -130,9 +130,12 @@ const Signin = () => {
             </MuiLink>
           </Box>
           <Box textAlign="center" sx={{ mt: 2 }}>
-            <MuiLink href="/auth/sign-up" variant="body2">
-              {"Don't have an account? Sign Up"}
-            </MuiLink>
+            <Typography variant="body2">
+              Don&apos;t have an account?&nbsp;
+              <MuiLink href="/auth/sign-up" variant="body2">
+                {"Sign Up"}
+              </MuiLink>
+            </Typography>
           </Box>
         </Box>
       </Paper>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -275,9 +275,12 @@ const SignUp = () => {
             Sign Up
           </Button>
           <Box textAlign="center" sx={{ mt: 2 }}>
-            <MuiLink href="/auth/sign-in" variant="body2">
-              Already have an account? Sign In
-            </MuiLink>
+            <Typography variant="body2">
+              Already have an account?{" "}
+              <MuiLink href="/auth/sign-in" variant="body2">
+                {"Sign In"}
+              </MuiLink>
+            </Typography>
           </Box>
         </Box>
       </Paper>

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -77,7 +77,7 @@ const CreateEvent: React.FC = () => {
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <Box component="form" onSubmit={handleSubmit} noValidate autoComplete="off" sx={{ p: 3, width: isMobile ? '100%' : '75%', mx: 'auto' }}>
           <Typography
-              fontSize={"2.25rem"}
+              fontSize={isMobile ? "1.75rem" : "2.25rem"}
               textAlign={"center"}
               marginTop={"0.5rem"}
               marginBottom={"1rem"}

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from "next/link";
-import { Box, Button, Container, Grid, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Button, Container, Grid, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { FC } from "react";
 import styles from "../home.module.css";
 import '../globals.css';
@@ -33,11 +33,18 @@ const Creator = () => {
     if (isAuth && user?.role === 'creator') {
         return (
             <Container maxWidth={false} className="bg-solid">
+                <Typography
+                    fontSize={isMobile ? "1.75rem" : "2.25rem"}
+                    textAlign={"center"}
+                    padding={"1rem"}
+                    marginTop={"1rem"}
+                    marginBottom={"1rem"}
+                >My Account</Typography>
                 <Box className={styles.title}
                      display="flex"
                      justifyContent="center"
                      alignItems="center"
-                     height="100vh"
+                     height="60vh"
                      flexDirection="column"
                 >
                     <Grid container spacing={2} justifyContent="center" alignItems="center">

--- a/app/theme/themes.tsx
+++ b/app/theme/themes.tsx
@@ -43,10 +43,24 @@ let darkTheme = createTheme({
     },
     MuiOutlinedInput: {
       styleOverrides: {
+        root: {
+          "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+            borderColor: "#fff",
+          },
+        },
         input: {
           '&:-webkit-autofill': {
-            '-webkit-box-shadow': '0 0 0 100px #E8F0FE inset',
-            '-webkit-text-fill-color': '#000',
+            '-webkit-box-shadow': '0 0 0 100px rgba(69, 69, 69) inset',
+            '-webkit-text-fill-color': '#fff',
+          },
+        },
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused': {
+            color: '#fff'
           },
         },
       },


### PR DESCRIPTION
Resolves #526 

This PR fixes the low contrast color of focused text fields on Sign up, Sign in, Forgot Password, Change password, & Add Product pages in dark mode and adds headings to the top of Admin and Creator pages that says "My Account".

Sign in page before:
<img width="200" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/b2af4eeb-81e6-4982-86d9-25ff4f2cc1f4">

Sign in page after:
<img width="200" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/f85bb861-903f-430d-bc8f-1fff40ae8d74">

Admin page:
<img width="500" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/18347bb4-11f8-4eb8-b46c-e967e935946c">

Creator page:
<img width="500" alt="image" src="https://github.com/SeattleColleges/nsc-events-nextjs/assets/77591083/11650b7a-a2a8-4130-af54-9fe0bf56f9a0">
