### PR TITLE
nsc-events-nextjs-9-529-load-more-events-with-arrows

### DIFF
--- a/app/archived-events/page.tsx
+++ b/app/archived-events/page.tsx
@@ -52,7 +52,9 @@ if (isAuth && (user?.role === 'admin' || user?.role === 'creator')) {
                         pathname: "/event-detail",
                         query: {
                             id: event._id,
-                            events: JSON.stringify(events.map(e => e._id))
+                            events: JSON.stringify(events.map(e => e._id)),
+                            from: 'archived',
+                            page: page
                         },
                     }
                 }>

--- a/app/archived-events/page.tsx
+++ b/app/archived-events/page.tsx
@@ -16,7 +16,7 @@ const ArchivedEvents = () => {
     const [page, setPage] = useState(1);
     const [hasReachedLastPage, setHasReachedLastPage] = useState(false);
     const [events, setEvents] = useState<ActivityDatabase[]>([]);
-    const { data } = useArchivedEvents(page);
+    const { data } = useArchivedEvents(page, true);
     const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
   
     useEffect(() => {

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -34,8 +34,9 @@ import ViewMoreDetailsDialog from "@/components/ViewMoreDetailsDialog";
 import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import { useTheme } from "@mui/material";
-import { useEventById } from "@/utility/queries";
+import { useArchivedEvents, useEventById, useFilteredEvents, useMyEvents } from "@/utility/queries";
 import theme from "../theme";
+import { getCurrentUserId } from "@/utility/userUtils";
 
 interface SearchParams {
   searchParams: {
@@ -50,7 +51,10 @@ const EventDetail = () => {
   const eventIds = searchParams.get("events");
   const queryClient = useQueryClient();
   const [event, setEvent] = useState<ActivityDatabase | null>(null);
-  const [events, setEvents] = useState<string[]>([]);
+  const [events, setEvents] = useState<string[]>( () => {
+        const events = localStorage.getItem('events');
+        return events ? JSON.parse(events) : [];
+  });
   const [isAuthed, setAuthed] = useState(false);
   const [token, setToken] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -65,7 +69,16 @@ const EventDetail = () => {
   const containerColor = palette.mode === "dark" ? "#333" : "#fff";
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
   const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
-
+  const [page, setPage] = useState(Number(searchParams.get("page")!) + 1)
+  const [reachedLastPage, setReachedLastPage] = useState(false);
+  const [prevPage] = useState( () => {
+    const prevPage = localStorage.getItem("prevPage")
+    return prevPage ? prevPage : searchParams.get("from")
+  })
+  const [ usedData, setUsedData] = useState([])
+  const { data: filteredEvents } = useFilteredEvents(page, prevPage === "home")
+  const { data: archivedEvents }  = useArchivedEvents(page, prevPage === "archived")
+  const { data: myEvents }  = useMyEvents(getCurrentUserId(), page, prevPage === "mine")
   const { data } = useEventById(id);
   const DeleteDialog = () => {
     return (

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -75,7 +75,7 @@ const EventDetail = () => {
     const prevPage = localStorage.getItem("prevPage")
     return prevPage ? prevPage : searchParams.get("from")
   })
-  const [ usedData, setUsedData] = useState([])
+  const [ usedData, setUsedData] = useState<ActivityDatabase[] | undefined>(undefined)
   const { data: filteredEvents } = useFilteredEvents(page, prevPage === "home")
   const { data: archivedEvents }  = useArchivedEvents(page, prevPage === "archived")
   const { data: myEvents }  = useMyEvents(getCurrentUserId(), page, prevPage === "mine")

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -161,6 +161,42 @@ const EventDetail = () => {
   });
 
   useEffect(() => {
+    if(prevPage) {
+      localStorage.setItem("prevPage", prevPage)
+    }
+    if(events) {
+      localStorage.setItem("events", JSON.stringify(events))
+    }
+    return () => {
+      localStorage.removeItem("events")
+      localStorage.removeItem("prevPage")
+    }
+  }, [events, prevPage]);
+
+  useEffect(() => {
+    switch (prevPage) {
+      case "home":
+        setUsedData(filteredEvents);
+        break;
+      case "archived":
+        setUsedData(archivedEvents);
+        break;
+      case "mine":
+        setUsedData(myEvents)
+        break;
+    }
+    if (usedData) {
+      setEvents((prevEvents) => {
+        const newEvents: string[] = [...prevEvents, ...usedData.map((e: { _id: string; }) => e._id)];
+        return newEvents.filter((event, index, self) =>
+            index === self.findIndex((e) => e === event)
+        );
+      });
+      setReachedLastPage(usedData.length === 0);
+    }
+  }, [archivedEvents, filteredEvents, myEvents, page, prevPage, queryClient, usedData]);
+
+  useEffect(() => {
     if (eventIds) {
       setEvents(JSON.parse(eventIds));
     }
@@ -197,6 +233,10 @@ const EventDetail = () => {
 
   const getNextEvent = () => {
     const currentIndex = events.findIndex(e => e === event?._id);
+    if(!reachedLastPage && events.findIndex(e => e === event?._id)) {
+      setPage(num => num + 1);
+    }
+
     if (currentIndex >= 0 && currentIndex < events.length - 1) {
       const nextEvent = events[currentIndex + 1];
       console.log("Navigating to:", nextEvent);

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -11,7 +11,7 @@ export function HomeEventsList(){
     const [page, setPage] = useState(1)
     const [events, setEvents] = useState<ActivityDatabase[]>([]);
     const [reachedLastPage, setReachedLastPage] = useState(false);
-    const { data } = useFilteredEvents(page);
+    const { data } = useFilteredEvents(page, true);
     useEffect(() => {
         if (data) {
             setEvents((prevEvents) => {

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -37,7 +37,9 @@ export function HomeEventsList(){
                             pathname: "/event-detail",
                             query: {
                                 id: event._id,
-                                events: JSON.stringify(events.map(e => e._id))
+                                events: JSON.stringify(events.map(e => e._id)),
+                                from: 'home',
+                                page: page,
                             },
                         }
                     } >

--- a/components/UpcomingEvent.tsx
+++ b/components/UpcomingEvent.tsx
@@ -16,7 +16,7 @@ import { useFilteredEvents } from "@/utility/queries";
 import { formatDate } from "@/utility/dateUtils";
 
 export function UpcomingEvent() {
-  const { data, isLoading, isError } = useFilteredEvents(1);
+  const { data, isLoading, isError } = useFilteredEvents(1, true);
 
   if (isLoading) {
     return <span>Loading events...</span>;

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -38,7 +38,9 @@ export function MyEventsList() {
                                 pathname: "/event-detail",
                                 query: {
                                     id: event._id,
-                                    events: JSON.stringify(events.map(e => e._id))
+                                    events: JSON.stringify(events.map(e => e._id)),
+                                    from: 'mine',
+                                    page: page,
                                 },
                             }
                         } >

--- a/components/ViewMyEventsGetter.tsx
+++ b/components/ViewMyEventsGetter.tsx
@@ -14,7 +14,7 @@ export function MyEventsList() {
     const [events, setEvents] = useState<ActivityDatabase[]>([]);
     const [page, setPage] = useState(1);
     const [hasReachedLastPage, setHasReachedLastPage] = useState(false)
-    const { data } = useMyEvents(getCurrentUserId(), page);
+    const { data } = useMyEvents(getCurrentUserId(), page, true);
     useEffect(() => {
         if (data) {
             setEvents((prevEvents) => [...prevEvents, ...data]);

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -11,10 +11,11 @@ const getEvents = async(page: any) => {
     const response = await fetch(`${apiUrl}/events?${params.toString()}`);
     return response.json();
 }
-export function useFilteredEvents(page: any) {
+export function useFilteredEvents(page: any, isEnabled: boolean) {
     return useQuery<ActivityDatabase[], Error>({
         queryKey: ["events", page],
         queryFn: () => getEvents(page),
+        enabled: isEnabled
     });
 }
 
@@ -27,10 +28,11 @@ const getArchivedEvents = async(page: any) => {
     const response = await fetch(`${apiUrl}/events?${String(params)}`);
     return response.json();
 }
-export function useArchivedEvents(page: any) {
+export function useArchivedEvents(page: any, isEnabled: boolean) {
     return useQuery<ActivityDatabase[], Error>({
         queryKey: ["archivedEvents", page],
         queryFn: async () => getArchivedEvents(page),
+        enabled: isEnabled
     });
 }
 
@@ -42,10 +44,11 @@ const getMyEvents = async(userId: string, page: any) => {
     const response = await fetch(`${apiUrl}/events/user/${userId}?${String(params)}`);
     return response.json();
 }
-export function useMyEvents(userId: string, page: any) {
+export function useMyEvents(userId: string, page: any, isEnabled: boolean) {
     return useQuery<ActivityDatabase[], Error>({
         queryKey: ["myEvents", page],
         queryFn: async () => getMyEvents(userId, page),
+        enabled: isEnabled
     });
 }
 


### PR DESCRIPTION
Satisfies #529 
This PR implements functionality to load more events with the event detail arrows.

- Updated the query hooks to use enabled option for conditional fetching of data
- Updated query hook calls to use the boolean
- Added "from" and "page" Searchparams to pages that route to event details
- Stored event id's and prev page information in local storage. Cleared when unmounting event details page

https://github.com/SeattleColleges/nsc-events-nextjs/assets/22021615/0f24676f-5cff-4a4c-b17b-e8ed8a997b5f

