### PR TITLE
nsc-events-nextjs_9_537_signin-change-forgot-pw-responsive-ui

### DIFF
--- a/app/auth/change-password/page.tsx
+++ b/app/auth/change-password/page.tsx
@@ -13,6 +13,7 @@ import {
   InputAdornment,
   IconButton,
   Link as MuiLink,
+  useMediaQuery,
 } from "@mui/material";
 import { textFieldStyle } from "@/components/InputFields";
 import { validateChangePassword } from "./validatePassword";
@@ -36,6 +37,10 @@ const ChangePassword = () => {
   const darkImagePath = white_vertical_nsc_logo;
   const lightImagePath = blue_vertical_nsc_logo;
   const imagePath = palette.mode === "dark" ? darkImagePath : lightImagePath;
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
   // Set initial state for password visibility
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
@@ -131,11 +136,12 @@ const ChangePassword = () => {
         alignItems: "center",
         height: "100vh",
         justifyContent: "center",
+        mt: isMobile ? -6 : isTablet ? -4 : -8
       }}
     >
       <Paper
         elevation={6}
-        sx={{ padding: 4, width: "100%", borderRadius: 2, mb: 15 }}
+        sx={{ padding: 4, width: "100%", borderRadius: 2, mb: 2 }}
       >
         <Box
           component="form"

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
-import { Box, Button, TextField, Typography, Container, Paper } from '@mui/material';
+import { Box, Button, TextField, Typography, Container, Paper, useMediaQuery } from '@mui/material';
 import { textFieldStyle } from "@/components/InputFields";
 import Image from "next/image";
 import blue_vertical_nsc_logo from 'public/images/blue_vertical_nsc_logo.png'
@@ -14,6 +14,10 @@ const ForgotPassword = () => {
   const darkImagePath = white_vertical_nsc_logo;
   const lightImagePath = blue_vertical_nsc_logo;
   const imagePath = palette.mode === "dark" ? darkImagePath : lightImagePath;
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
   // user email state
   const [userEmail, setUserEmail] = useState({ email: "" });
@@ -35,8 +39,24 @@ const ForgotPassword = () => {
   };
 
   return (
-    <Container component="main" maxWidth="xs" sx={{ display: 'flex', alignItems: 'center', height: '100vh' }}>
-      <Paper elevation={6} sx={{ padding: 4, width: '100%', borderRadius: 2, mb: 2 }}>
+    <Container component="main" 
+      maxWidth="xs" 
+      sx={{ 
+        display: 'flex', 
+        alignItems: 'center', 
+        height: '100vh',
+        mt: isMobile ? -16 : isTablet ? -14 : -18
+      }}
+    >
+      <Paper 
+        elevation={6} 
+        sx={{ 
+          padding: 4, 
+          width: '100%', 
+          borderRadius: 2, 
+          mb: 2 
+        }}
+      >
         <Box sx={{ display: 'flex', justifyContent: 'center', marginBottom: 2 }}>
         <Image
             src={imagePath.src}
@@ -46,7 +66,7 @@ const ForgotPassword = () => {
             style={{ borderRadius: "10px" }}
           />
         </Box>
-        <Typography component="h1" variant="h5" textAlign="center" sx={{ mb: 2 }}>
+        <Typography component="h1" variant="h6" textAlign="center" sx={{ mb: 2 }}>
           Forgot Password
         </Typography>
         <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -3,7 +3,7 @@
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import { Container, Paper, Box, TextField, Button, Typography, Link as MuiLink } from "@mui/material";
+import { Container, Paper, Box, TextField, Button, Typography, Link as MuiLink, useMediaQuery } from "@mui/material";
 import { textFieldStyle } from "@/components/InputFields";
 import blue_vertical_nsc_logo from 'public/images/blue_vertical_nsc_logo.png'
 import white_vertical_nsc_logo from 'public/images/white_vertical_nsc_logo.png'
@@ -26,6 +26,10 @@ const Signin = () => {
   });
 
   const router = useRouter();
+  
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
   const { email, password } = userInfo;
 
@@ -66,9 +70,36 @@ const Signin = () => {
   };
 
   return (
-    <Container maxWidth="xs" sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', height: '100vh', justifyContent: 'center' }}>
-      <Paper elevation={6} sx={{ padding: 4, width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', borderRadius: 2, mb: 2 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'center', marginBottom: 2 }}>
+    <Container 
+      maxWidth="xs" 
+      sx={{ 
+        display: 'flex', 
+        flexDirection: 'column', 
+        alignItems: 'center', 
+        height: '100vh', 
+        justifyContent: 'center',
+        mt: isMobile ? -8 : isTablet ? -6 : -10
+      }}
+    >
+      <Paper 
+        elevation={6} 
+        sx={{ 
+          padding: 4, 
+          width: '100%', 
+          display: 'flex', 
+          flexDirection: 'column', 
+          alignItems: 'center', 
+          borderRadius: 2, 
+          mb: 2 
+        }}
+      >
+        <Box 
+          sx={{ 
+            display: 'flex', 
+            justifyContent: 'center', 
+            marginBottom: 2 
+          }}
+        >
           <Image
             src={imagePath.src}
             alt="North Seattle College Logo"


### PR DESCRIPTION
Resolves #537

This PR ensures that the Sign In, Change and Forgot Password pages has responsive UI and adjusts to mobile screen sizes well, with no cutoff or scrolling horizontally. I also made improvements to the appearance of the pages for tablet and desktop screen sizes.

Test this PR by right clicking the page and using Inspect elements to enter the Toggle Device Toolbar and adjust the screen sizes.

![Screenshot 2024-07-13 183359](https://github.com/user-attachments/assets/d3c3bf05-87eb-450b-b2d1-ea9a6fc7cb52)
![Screenshot 2024-07-13 183418](https://github.com/user-attachments/assets/c145c0f8-d5bf-4c70-87a6-92f437efa9e1)
![Screenshot 2024-07-13 183800](https://github.com/user-attachments/assets/0bc72dcc-16e6-41e5-bc4a-01073082eb9a)
![Screenshot 2024-07-13 183826](https://github.com/user-attachments/assets/950d44ce-275d-4dc2-ad0a-97e9b8f50a03)
![Screenshot 2024-07-13 183841](https://github.com/user-attachments/assets/9ca72958-a7ed-4ae0-ad2e-0fb52f71be1c)
![Screenshot 2024-07-13 183856](https://github.com/user-attachments/assets/9798c387-a878-4c76-90f3-fc438cf65510)
![Screenshot 2024-07-13 184039](https://github.com/user-attachments/assets/f69fdf77-bfca-4c5c-815e-746c2cc594bf)
![Screenshot 2024-07-13 184051](https://github.com/user-attachments/assets/e0ca8e28-10ee-4f0e-8e74-04b00ba6bb46)
![Screenshot 2024-07-13 184614](https://github.com/user-attachments/assets/eff51494-dfa3-41f3-a5f5-32dea9aeebec)
