### PR TITLE
nsc-events-nextjs-9-544-event-note-optional-visible-only-createdby-admin

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -445,7 +445,7 @@ const EventDetail = () => {
           event={event}
           userRole={userRole}
           dialogToggle={toggleViewMoreDetailsDialog}
-        />
+          userId={userId}/>
         <AttendDialog
           isOpen={attendDialogOpen}
           eventId={event._id}

--- a/components/ViewMoreDetailsDialog.tsx
+++ b/components/ViewMoreDetailsDialog.tsx
@@ -29,6 +29,7 @@ interface ViewMoreDetailsDialogProps {
   event: ActivityDatabase;
   // current user's role so we can display details based on role
   userRole: string;
+  userId: string;
   dialogToggle: () => void;
 }
 
@@ -36,6 +37,7 @@ function ViewMoreDetailsDialog({
   isOpen,
   event,
   userRole,
+  userId,
   dialogToggle,
 }: ViewMoreDetailsDialogProps) {
   // Simple "array to string" function for handling activity details that are arrays

--- a/components/ViewMoreDetailsDialog.tsx
+++ b/components/ViewMoreDetailsDialog.tsx
@@ -42,6 +42,7 @@ function ViewMoreDetailsDialog({
 }: ViewMoreDetailsDialogProps) {
   // Simple "array to string" function for handling activity details that are arrays
   const arrayToString = (arr: any[]) => arr.join(", ");
+  const isCreatorOfEvent = userId === event.createdByUser
 
   const moreDetails = [
     { title: "Host", detail: event.eventHost },
@@ -65,7 +66,7 @@ function ViewMoreDetailsDialog({
     { title: "Archived", detail: event.isArchived ? "Yes" : "No" },
   ];
 
-  const adminDetails = [{ title: "Event Note", detail: event.eventNote }];
+  const eventNoteDetail = [{ title: "Event Note", detail: event.eventNote }];
 
   // Simple function to check if the event details being mapped is an object
   const isObject = (value: any) => value && typeof value === "object" && !Array.isArray(value);
@@ -114,7 +115,7 @@ function ViewMoreDetailsDialog({
           {/* map out the moreDetails object as a ListItem for each, handle each user role differently*/}
           {mapDetails(moreDetails)}
           {(userRole == "creator" || userRole == "admin") && <>{mapDetails(creatorDetails)}</>}
-          {userRole == "admin" && <>{mapDetails(adminDetails)}</>}
+          {(userRole == "admin" || isCreatorOfEvent) && <>{mapDetails(eventNoteDetail)}</>}
         </DialogContent>
 
         {/* cancel button to exit the dialog box */}


### PR DESCRIPTION
Satisfies #544 

This PR makes the event notes visible only to the creator of the event or user with the role "admin"

https://github.com/user-attachments/assets/e9504d8d-1d37-4f3e-ba00-0628f2e1eb04

