### PR TITLE
nsc-events-nextjs-10-548-home-page-filter-events-by-tag

### DIFF
--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -12,6 +12,7 @@ import { textFieldStyle } from "@/components/InputFields"
 import { MouseEvent, ChangeEvent, useState, FormEvent } from "react";
 import useAuth from "@/hooks/useAuth";
 import UnauthorizedPageMessage from "@/components/UnauthorizedPageMessage";
+import {EventTags} from "@/utility/tags";
 
 const CreateEvent: React.FC = () => {
   const {
@@ -229,27 +230,13 @@ const CreateEvent: React.FC = () => {
             placeholder="Enter the capacity of the event"
           />
           <TagSelector
-            selectedTags={eventData.eventTags}
-            allTags={[
-              ...["Professional Development",
-              "Club",
-              "Social",
-              "Tech",
-              "Cultural",
-              "Study",
-              "Coffee",
-              "Art/Creative",
-              "Conference",
-              "Craft",
-              "Networking",
-              "Pizza",
-              "Free Food",
-              "LGBTQIA",
-              ],
-              ...customTags
-            ]}
-            onTagClick={handleTagClick}
-          />      
+              selectedTags={eventData.eventTags}
+              allTags={[
+                  ...EventTags,
+                  ...customTags
+              ]}
+              onTagClick={handleTagClick}
+          />
           <Box>
             <TextField
               id="add-custom-tag"

--- a/app/create-event/page.tsx
+++ b/app/create-event/page.tsx
@@ -12,7 +12,7 @@ import { textFieldStyle } from "@/components/InputFields"
 import { MouseEvent, ChangeEvent, useState, FormEvent } from "react";
 import useAuth from "@/hooks/useAuth";
 import UnauthorizedPageMessage from "@/components/UnauthorizedPageMessage";
-import {EventTags} from "@/utility/tags";
+import { EventTags } from "@/utility/tags";
 
 const CreateEvent: React.FC = () => {
   const {

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from "react";
-import {Grid, Button, useMediaQuery, useTheme, Container, Box} from '@mui/material';
+import { Grid, Button, useMediaQuery, useTheme, Container, Box } from '@mui/material';
 import { ActivityDatabase } from "@/models/activityDatabase";
 import EventCard from "./EventCard";
 import { useFilteredEvents } from "@/utility/queries";
@@ -49,11 +49,9 @@ export function HomeEventsList(){
         });
         if (newEvents.length > 0) {
             setEvents(newEvents);
-        } else {
-            if (data) {
-                setPage(1);
-                refetch().then(res => setEvents(res.data as ActivityDatabase[]));
-            }
+        } else if (data) {
+            setPage(1);
+            refetch().then(res => setEvents(res.data as ActivityDatabase[]));
         }
     }, [activeTags]);
     return (

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from "react";
-import {Grid, Button, useMediaQuery, useTheme, Container, Box, Typography} from '@mui/material';
+import { Grid, Button, useMediaQuery, useTheme, Container, Box, Typography } from '@mui/material';
 import { ActivityDatabase } from "@/models/activityDatabase";
 import EventCard from "./EventCard";
 import { useFilteredEvents } from "@/utility/queries";

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -6,6 +6,8 @@ import { ActivityDatabase } from "@/models/activityDatabase";
 import EventCard from "./EventCard";
 import { useFilteredEvents } from "@/utility/queries";
 import Link from "next/link";
+import TagSelector from "@/components/TagSelector";
+import { EventTags } from "@/utility/tags";
 
 export function HomeEventsList(){
     const [page, setPage] = useState(1)
@@ -41,7 +43,14 @@ export function HomeEventsList(){
                 alignItems="center"
                 sx={{ m: "auto" }}
             >
-            {
+                <TagSelector
+                    selectedTags={['']}
+                    allTags={[
+                        ...EventTags,
+                    ]}
+                    onTagClick={(tag) => console.log(tag)}
+                />
+                {
                 events?.map((event: ActivityDatabase) => (
                     <Grid item xs={12} key={event._id}>
                         <Link key={event._id} href={

--- a/components/HomeEventGetter.tsx
+++ b/components/HomeEventGetter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from "react";
-import { Grid, Button, useMediaQuery, useTheme, Container, Box } from '@mui/material';
+import {Grid, Button, useMediaQuery, useTheme, Container, Box, Typography} from '@mui/material';
 import { ActivityDatabase } from "@/models/activityDatabase";
 import EventCard from "./EventCard";
 import { useFilteredEvents } from "@/utility/queries";
@@ -17,7 +17,7 @@ export function HomeEventsList(){
     const theme = useTheme();
     const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
     const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
-    const { data, refetch } = useFilteredEvents(page, true);
+    const { data, isLoading } = useFilteredEvents(page, true, activeTags);
 
     useEffect(() => {
         if (data) {
@@ -36,6 +36,8 @@ export function HomeEventsList(){
         setPage(num => num + 1);
     };
     const handleTagClicked = (clickedTag: string) => {
+        setEvents([])
+        setPage(1)
         if (activeTags.includes(clickedTag)) {
             const newTags = activeTags.filter(t => t !== clickedTag);
             setActiveTags(newTags);
@@ -43,17 +45,6 @@ export function HomeEventsList(){
             setActiveTags((prevTags) => [...prevTags, clickedTag]);
         }
     }
-    useEffect(() => {
-        const newEvents = events.filter(e => {
-           return e.eventTags.some(tag => activeTags.includes(tag));
-        });
-        if (newEvents.length > 0) {
-            setEvents(newEvents);
-        } else if (data) {
-            setPage(1);
-            refetch().then(res => setEvents(res.data as ActivityDatabase[]));
-        }
-    }, [activeTags]);
     return (
         <Container maxWidth={false}>
             <Grid
@@ -76,6 +67,7 @@ export function HomeEventsList(){
                     />
                 </Box>
                 {
+                    events.length > 0 ?
                 events?.map((event: ActivityDatabase) => (
                     <Grid item xs={12} key={event._id}>
                         <Link key={event._id} href={
@@ -95,9 +87,12 @@ export function HomeEventsList(){
                         />
                         </Link>
                     </Grid>
-                ))}
+                )): <Typography>
+                            { isLoading ? 'Loading...': 'Found no events with selected tags!' }
+                    </Typography>
+                }
             {
-                !reachedLastPage &&
+                data && data.length > 0 && !reachedLastPage &&
                 <Button onClick={handleLoadMoreEvents}
                         type="button"
                         variant="contained"

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -3,18 +3,19 @@ import { ActivityDatabase } from "@/models/activityDatabase";
 import React from "react";
 
 const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
-const getEvents = async(page: any) => {
+const getEvents = async(page: any, tags: string[]) => {
     const params = new URLSearchParams({
         page: String(page),
         isArchived: String(false),
+        tags: String(tags),
     });
     const response = await fetch(`${apiUrl}/events?${params.toString()}`);
     return response.json();
 }
-export function useFilteredEvents(page: any, isEnabled: boolean) {
+export function useFilteredEvents(page: any, isEnabled: boolean, tags: string[] = []) {
     return useQuery<ActivityDatabase[], Error>({
-        queryKey: ["events", page],
-        queryFn: () => getEvents(page),
+        queryKey: ["events", page, tags],
+        queryFn: () => getEvents(page, tags),
         enabled: isEnabled
     });
 }

--- a/utility/tags.ts
+++ b/utility/tags.ts
@@ -1,0 +1,16 @@
+export const EventTags: string[] = [
+    "Professional Development",
+    "Club",
+    "Social",
+    "Tech",
+    "Cultural",
+    "Study",
+    "Coffee",
+    "Art/Creative",
+    "Conference",
+    "Craft",
+    "Networking",
+    "Pizza",
+    "Free Food",
+    "LGBTQIA",
+];


### PR DESCRIPTION
Resolves #548 

Implements filtering the events list on the home page by tags using the TagSelector component. Only events with all of the tags selected will be returned. 
I also moved the list of tags to a separate file `tags.ts` in the `/utility` directory to to be exported and reduce duplicated code. 

Note: Test with the local API as these changes depend on a commit recently merged to the nsc-events-nestjs main branch.

https://github.com/user-attachments/assets/fe971dec-571c-4b51-ba64-dac95c40b3c7

