### PR TITLE
update files to support env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,11 @@
+# Copy and paste to new .env file
 MONGODB_URI=<replace-your-connection-string>/nsc_events_db
 NEXTAUTH_URL=http://localhost:3001
 NEXTAUTH_SECRET=secret
 JWT_SECRET=secret
 JWT_EXPIRES="1d"
 PRODUCT_KEY=secret
+API_URL=http://localhost:3001/api
+# Public API: https://northseattlecollegeevents.com/api
+# Dev API: http://localhost:3001/api  
+# Ensure local API port matches with Server port number

--- a/.env.sample
+++ b/.env.sample
@@ -8,4 +8,4 @@ PRODUCT_KEY=secret
 API_URL=http://localhost:3001/api
 # Public API: https://northseattlecollegeevents.com/api
 # Dev API: http://localhost:3001/api  
-# Ensure local API port matches with Server port number
+# Ensure local API port value matches with Nest.js app.listen port value

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -8,7 +8,7 @@ import blue_vertical_nsc_logo from 'public/images/blue_vertical_nsc_logo.png';
 import white_vertical_nsc_logo from 'public/images/white_vertical_nsc_logo.png';
 import { useTheme } from "@mui/material";
 
-const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL;
 
 
 const ForgotPassword = () => {

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -9,7 +9,10 @@ import blue_vertical_nsc_logo from 'public/images/blue_vertical_nsc_logo.png'
 import white_vertical_nsc_logo from 'public/images/white_vertical_nsc_logo.png'
 import { useTheme } from "@mui/material";
 
-const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL;
+if (URL?.includes('localhost')) {
+  console.log('Dev API Address: ',URL)
+}
 
 // similar to sign-up page, but we're only handling email and password. 
 const Signin = () => {

--- a/app/auth/sign-up/signupApi.tsx
+++ b/app/auth/sign-up/signupApi.tsx
@@ -1,4 +1,4 @@
-const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
 interface SignUpPayload {
   firstName: string;
   lastName: string;
@@ -23,6 +23,10 @@ type SignUpResponse = SignUpSuccessResponse | SignUpErrorResponse;
 export const signUp = async (
   payload: SignUpPayload
 ): Promise<SignUpResponse> => {
+    if (apiUrl?.includes('localhost')) {
+    console.log('Dev API Address: ',apiUrl)
+  }
+
   try {
     const response = await fetch(`${apiUrl}/auth/signup`, {
       method: "POST",

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -21,7 +21,7 @@ interface User {
  */
 async function fetchUser(setUserInfo: (userInfo: User[]) => void) {
   const token = localStorage.getItem("token");
-  const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+  const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
   try {
     const res = await fetch(`${apiUrl}/users`, {
       method: "GET",

--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -126,7 +126,7 @@ const EventDetail = () => {
 
   const deleteEvent = async (id: string) => {
     try {
-      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
       const response = await fetch(`${apiUrl}/events/remove/${id}`, {
         method: 'DELETE',
         headers: {

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,7 +9,7 @@ import useAuth from "@/hooks/useAuth";
 import UnauthorizedPageMessage from "@/components/UnauthorizedPageMessage";
 import EditUserDetailsDialog, { User } from "@/components/EditUserDetailsDialog";
 
-const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL;
 
 const Profile = () => {
     const { isAuth } = useAuth();

--- a/components/ArchiveDialog.tsx
+++ b/components/ArchiveDialog.tsx
@@ -23,7 +23,7 @@ const ArchiveDialog = ({ isOpen, event, dialogToggle }: ArchiveDialogProps) => {
   const archiveEvent = async (id: string) => {
     const token = localStorage.getItem("token");
     try {
-      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
       const response = await fetch(`${apiUrl}/events/archive/${id}`, {
         method: "PUT",
         headers: {

--- a/components/AttendDialog.tsx
+++ b/components/AttendDialog.tsx
@@ -52,7 +52,7 @@ const AttendDialog = ( { isOpen, eventId, dialogToggle }: AttendDialogProps) => 
         }
 
         try {
-            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
             const response = await fetch(`${apiUrl}/events/attend/${id}`, options );
             return response.json();
         } catch (error) {

--- a/components/EditUserDetailsDialog.tsx
+++ b/components/EditUserDetailsDialog.tsx
@@ -45,7 +45,7 @@ const EditUserDetailsDialog: React.FC<EditUserDetailsDialogProps> = ({ open, onC
   const handleSave = async () => {
     const token = localStorage.getItem('token');
     try {
-      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
       const response = await fetch(`${apiUrl}/users/update/${user.id}`, {
         method: 'PATCH',
         headers: {

--- a/components/EventGetter.tsx
+++ b/components/EventGetter.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardMedia, Typography, Grid, Box, CardActions, Button } from '@mui/material';
 import Link from "next/link";
 import { ActivityDatabase } from "@/models/activityDatabase";
-const URL = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const URL = process.env.NSC_EVENTS_PUBLIC_API_URL;
 
 const getEvents = async() => {
     const response = await fetch(`${URL}/events`);

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -36,7 +36,7 @@ function UserCard({ user }: { user: UserCardProps }) {
     if (editCompleted) {
       const token = localStorage.getItem('token');
       try {
-        const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+        const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
         const response = await fetch(`${apiUrl}/users/update/${user.id}`, {
           method: 'PATCH',
           headers: {

--- a/hooks/useEditForm.tsx
+++ b/hooks/useEditForm.tsx
@@ -89,7 +89,7 @@ const to24HourTime  = (time: string) => {
 
 
     try {
-      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
       const response = await fetch(`${apiUrl}/events/update/${dataToSend._id}`, {
         method: "PUT",
         headers: {

--- a/hooks/useEventForm.tsx
+++ b/hooks/useEventForm.tsx
@@ -152,7 +152,7 @@ export const useEventForm = (initialData: Activity | ActivityDatabase) => {
     console.log("Event data after applying transformation: ", dataToSend);
 
     try {
-      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || `http://localhost:3000/api`;
+      const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
       const response = await fetch(`${apiUrl}/events/new`, {
         method: "POST",
         headers: {

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   env: { 
-  // Double check which to comment out
     // TODO: PULL THIS FROM GITHUB ACTIONS
-    // NSC_EVENTS_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,// Connects locally
-    NSC_EVENTS_PUBLIC_API_URL: "https://northseattlecollegeevents.com/api",
+    NSC_EVENTS_PUBLIC_API_URL: process.env.API_URL,// Connects locally
   },
 }
 

--- a/utility/queries.ts
+++ b/utility/queries.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import React from "react";
 
-const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL || "http://localhost:3000/api";
+const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
 const getEvents = async(page: any, tags: string[]) => {
     const params = new URLSearchParams({
         page: String(page),


### PR DESCRIPTION
This PR contains a quality of life update! Now you can set the API address from your .env file. If the developer is using a localhost based API address, the API address will be printed to the console.

How to test:
- Use the .env.sample to help set up your .env file. Once set, use `npm run dev` and run backend
- Make sure localhost port number matches with backend port number