### PR TITLE
nsc-events-nextjs_12_522_pronoun-error-message-bugfix

### DIFF
--- a/app/auth/sign-up/signupApi.tsx
+++ b/app/auth/sign-up/signupApi.tsx
@@ -2,6 +2,7 @@ const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
 interface SignUpPayload {
   firstName: string;
   lastName: string;
+  pronouns: string;
   email: string;
   password: string;
   role: string;

--- a/app/auth/sign-up/validateSignUp.tsx
+++ b/app/auth/sign-up/validateSignUp.tsx
@@ -1,6 +1,9 @@
+import { PersonOutlineSharp } from "@mui/icons-material";
+
 interface SignUpForm {
     firstName: string;
     lastName: string;
+    pronouns: string;
     email: string;
     password: string;
     confirmPassword: string;
@@ -10,7 +13,7 @@ export const validateSignUp = (values: SignUpForm) => {
 
     const errors: Partial<SignUpForm> = {};
 
-    const { firstName, lastName, email, password, confirmPassword } = values;
+    const { firstName, lastName, pronouns, email, password, confirmPassword } = values;
 
     if (!firstName) {
         errors.firstName = "First name is required";
@@ -18,6 +21,10 @@ export const validateSignUp = (values: SignUpForm) => {
     
     if (!lastName) {
         errors.lastName = "Last name is required";
+    }
+
+    if (!pronouns) {
+        errors.pronouns = "Pronouns is required";
     }
 
     if (!email) {


### PR DESCRIPTION
Please fill out this description with the following:
Resolves #522 

This PR is for fixing the bug of the required message not appearing for the pronoun field when signing up as a new user. 

the images below show the bugfix when testing out my branch:

image 1: no info 
![nsc-events-signup-pronoun1](https://github.com/user-attachments/assets/0108dd59-4543-4beb-9a99-5d980f560dee)

image 2: all info, pronoun field empty
![nsc-events-signup-pronoun2](https://github.com/user-attachments/assets/5d859f98-05ff-43fe-a7d8-363591b140df)

image 3: all info and clicking sign up
![nsc-events-signup-pronoun3](https://github.com/user-attachments/assets/ff7f0245-c7c1-4e4f-89ff-7d62be98d0f3)

For the third image, I'm currently not connected to a database so that's why that error message pops up on the bottom. It should be fine if your local database is configured on your end but if you experience problems when signing up let me know (but it should be fine I think).  

for testing, just clone branch or git checkout and run `npm install` first then `npm run dev` and click on sign up button to navigate to page.  
 
