### PR TITLE
highlight and gray the toggle theme icon on mouse hover

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,9 +5,9 @@ import Image from 'next/image';
 import MenuIcon from '@mui/icons-material/Menu';
 import { AppBar, Toolbar, IconButton, Grid, Button, Drawer, List, ListItem, ListItemText, useTheme, useMediaQuery, Box, Tooltip, Avatar, Menu, Typography, MenuItem } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import DrawerComp from './DrawerComp'; 
-import useAuth from '../hooks/useAuth'; 
-import AuthProfileMenu from './AuthProfileMenu'; 
+import DrawerComp from './DrawerComp';
+import useAuth from '../hooks/useAuth';
+import AuthProfileMenu from './AuthProfileMenu';
 import ThemeToggle from './ThemeToggle';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -13,12 +13,28 @@ const ThemeToggle = () => {
 
   // Render the appropriate icon based on the current theme mode
   if (mode === "light") {
-    return <FiMoon onClick={toggleTheme} aria-label="Toggle Dark Theme" />;
+    return (
+      <FiMoon
+        onClick={toggleTheme}
+        aria-label="Toggle Dark Theme"
+        style={{ cursor: "pointer" }}
+        onMouseOver={(e) => (e.currentTarget.style.color = "gray")}
+        onMouseOut={(e) => (e.currentTarget.style.color = "inherit")}
+      />
+    );
   }
 
   // Render the appropriate icon based on the current theme mode
   if (mode === "dark") {
-    return <FiSun onClick={toggleTheme} aria-label="Toggle Light Theme" />;
+    return (
+      <FiSun
+        onClick={toggleTheme}
+        aria-label="Toggle Light Theme"
+        style={{ cursor: "pointer" }}
+        onMouseOver={(e) => (e.currentTarget.style.color = "gray")}
+        onMouseOut={(e) => (e.currentTarget.style.color = "inherit")}
+      />
+    );
   }
 };
 


### PR DESCRIPTION
**Changes:**
Changes made to the ThemeToggle.tsx file in components folder. 



https://github.com/user-attachments/assets/403468f4-0c8f-4dab-831a-1756704ac112


## How to Test 🧪
1. Switch nsc-events-nextjs branch to 637-feature-add-mouseover-effect-to-lightdark-mode-nav-bar
2. Run the app and you can view the nav bar to check mouseover effect functionality. 
