### PR TITLE
nsc-events-nextjs_20_636_modify-textfield-CSS-user-management-page

### DIFF
--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -191,7 +191,7 @@ const EditUserRolePage = () => {
             sx={{
               padding: "1rem",
               display: "flex",
-              flexDirection: "row", // Arrange search bars horizontally
+              flexDirection: isMobile ? "column" : "row", // Arrange search bars horizontally
               justifyContent: "space-between", // Space out search bars
               gap: "1rem", // Space between search bars
               width: "100%",
@@ -200,7 +200,7 @@ const EditUserRolePage = () => {
             }}
           >
             {/* First Name Search Bar */}
-            <Box sx={{ width: "22%" }}>
+            <Box sx={{ width: "22%", [theme.breakpoints.down("sm")]: { width: "100%" } }}>
               <TextField
                 id="outlined"
                 label="First Name"
@@ -211,7 +211,7 @@ const EditUserRolePage = () => {
               />
             </Box>
             {/* Last Name Search Bar */}
-            <Box sx={{ width: "22%" }}>
+            <Box sx={{ width: isMobile ? "100%" : "22%" }}>
               <TextField
                 id="outlined"
                 label="Last Name"
@@ -222,7 +222,7 @@ const EditUserRolePage = () => {
               />
             </Box>
             {/* Email Search Bar */}
-            <Box sx={{ width: "22%" }}>
+            <Box sx={{ width: isMobile ? "100%" : "22%" }}>
               <TextField
                 id="outlined"
                 label="Email"
@@ -233,7 +233,7 @@ const EditUserRolePage = () => {
               />
             </Box>
             {/* Role Filter Dropdown */}
-            <Box sx={{ width: "22%" }}>
+            <Box sx={{ width: isMobile ? "100%" : "22%" }}>
               <FormControl fullWidth>
                 <InputLabel id="role-filter-label" shrink>Role</InputLabel>
                 <Select

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -200,7 +200,7 @@ const EditUserRolePage = () => {
             }}
           >
             {/* First Name Search Bar */}
-            <Box sx={{ width: "22%", [theme.breakpoints.down("sm")]: { width: "100%" } }}>
+            <Box sx={{ width: isMobile ? "100%" : "22%" }}>
               <TextField
                 id="outlined"
                 label="First Name"


### PR DESCRIPTION


<!-- Please fill out the following: -->
## Sunmmary & Changes 📃
- **Resolves:** #636 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 This PR fixes the issue of the text fields not stacking when on smaller screens for the user management page (edit-user-role-page). The page uses the already established mediaQuery variable `isMobile` on line 37 to make the changes.  This was a simple fix on certain box components.  
  - 👀 When viewing on mobile or a smaller screen, the search fields will stack on top of each instead of shrinking like before.
  - 🗨️ None

- **Changes:**
  - ✅ Added an `isMobile ?` check on line 194 for flex direction to display either 'column' or 'row' based on the screen size (currently at 600px) on the outer box that encompasses the search fields 
  - ✅ Added an `isMobile ?` check on lines 203, 214, 225, and 236 for displaying either "100%" or "22%" width based on the screen size on each of the search field box components.     
  - 🛠️ Mention breaking changes (if any) - None
  - 🔗 Link relevant discussions/issues - None 
  - 📝 Additional info to assist developers & reviewers - None


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

Video Link showcasing changes:
https://github.com/user-attachments/assets/8c2223b5-9906-45da-b543-3e55284f23f8


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: checkout branch and `npm install` 
   - Step 2: then `run npm dev` to start server and navigate to /edit-user-role-page (you can view the page without admin auth) 
   - Step 3: backend connection is optional if you want to test with users in the user table (my video shows that)
2. **Expected Behavior:** The text fields will stack on smaller screens 
3. **Actual Behavior (if bug):** (None)


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [x] **Squash commits** and enable **auto-merge** if approved.