### PR TITLE
nsc-events-nextjs_22_644_Fix_issue_where_clicking_anywhere_inside_the_TagSelector_component 

### DIFF
--- a/components/TagSelector.tsx
+++ b/components/TagSelector.tsx
@@ -11,23 +11,20 @@ type TagSelectorProps = {
 
 const TagSelector: React.FC<TagSelectorProps> = ({ selectedTags, allTags, onTagClick }) => {
     return (
-        <label>
-            
-            <Stack direction="row" spacing={1} className="mt-2" flexWrap="wrap" useFlexGap>
-                {allTags.map(tag => (
-                    <Button
-                        key={tag}
-                        variant={selectedTags.includes(tag) ? 'contained' : 'outlined'}
-                        color="primary"
-                        onClick={() => onTagClick(tag)}
-                        size="small"
-                        style={{ textTransform: 'capitalize' }}
-                    >
-                        {tag}
-                    </Button>
-                ))}
-            </Stack>
-        </label>
+        <Stack direction="row" spacing={1} className="mt-2" flexWrap="wrap" useFlexGap>
+            {allTags.map(tag => (
+                <Button
+                    key={tag}
+                    variant={selectedTags.includes(tag) ? 'contained' : 'outlined'}
+                    color="primary"
+                    onClick={() => onTagClick(tag)}
+                    size="small"
+                    style={{ textTransform: 'capitalize' }}
+                >
+                    {tag}
+                </Button>
+            ))}
+        </Stack>
     );
 };
 


### PR DESCRIPTION
<!-- Please fill out the following: -->
## Sunmmary & Changes 📃
- **Resolves:** `#644`

- **Summary:** (Briefly describe what this PR does)
Fixes an issue with the buttons de-selecting when you click anything

- **Changes:**
It turned out to be a very dumb and simple issue, but it took a while to figure out, <label> was the problem.


## How to Test 🧪
Do the following and make sure that this no longer occurs

![XZXHHIZ](https://github.com/user-attachments/assets/c99ae00c-14bd-4efd-bcb0-ab88c4a6cd4f)


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

