### PR TITLE
nsc-events-nextjs_20_651_bug-fix-overlap-style-issue-homeeventcard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -129,7 +129,7 @@ const Home = () => {
           />
         )}
       </Box>
-      <Grid container sx={{ mx: 15 }}>
+      <Grid container spacing={4} sx={{ px: 2 }}> {/* Can be modified if needed (mx: 15)*/}
         {/* Display the events */}
         {data && data.length > 0 ? (
           data.map((event: ActivityDatabase) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ import Grid from "@mui/material/Grid";
 import { useTheme } from "@mui/material";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import { useFilteredEvents } from "@/utility/queries";
-import HomeEventCard from "@/components/HomeEventCard";
+import HomeEventsCard from "@/components/HomeEventsCard";
 import { EventTags } from "@/utility/tags";
 import TagSelector from "@/components/TagSelector";
 import Link from "next/link";
@@ -134,7 +134,7 @@ const Home = () => {
         {events && events.length > 0 ? (
           events.map((event: ActivityDatabase) => (
             <Grid size={{ md: 12, lg: 6 }} key={event._id} sx={{}}>
-              <HomeEventCard event={event} />
+              <HomeEventsCard event={event} />
             </Grid>
           ))
         ) : (

--- a/components/HomeEventCard.tsx
+++ b/components/HomeEventCard.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { formatDate } from "@/utility/dateUtils";
 import { ActivityDatabase } from "@/models/activityDatabase";
 
+// declare the event prop that will get passed to the component
 interface EventCardProps {
     event: ActivityDatabase;
 }
@@ -49,7 +50,7 @@ function HomeEventCard({ event }: EventCardProps) {
                         image={event.eventCoverPhoto}
                         alt={event.eventTitle}
                         sx={{
-                            height: "auto",
+                            height: 250, // fixed height of the image
                             objectFit: "cover",
                             marginBlock: 2,
                             marginLeft: 2,
@@ -81,8 +82,12 @@ function HomeEventCard({ event }: EventCardProps) {
                     >
                         <Box sx={{ flex: 1, minWidth: 0 }}> {/* prevent overflow from children */}
                             <Link
-                                href={{ pathname: "/event-detail", query: { id: event._id } }}
-                                style={{ textDecoration: "none", display: "block" }}
+                                key={event._id}
+                                href={{ 
+                                    pathname: "/event-detail", 
+                                    query: { id: event._id } 
+                                }}
+                                style={{ textDecoration: "none", display: "block" }} // prevent underline on header
                             >
                                 <Box
                                     sx={{

--- a/components/HomeEventCard.tsx
+++ b/components/HomeEventCard.tsx
@@ -1,136 +1,194 @@
-"use client";
-import { Box, Card, CardContent, CardHeader, CardMedia, Typography, useMediaQuery, useTheme, Button } from '@mui/material';
-import { ActivityDatabase } from "@/models/activityDatabase";
-import React from 'react'
+import {
+    Box,
+    Card,
+    CardContent,
+    CardMedia,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from "@mui/material";
+import React from "react";
+import Link from "next/link";
 import { formatDate } from "@/utility/dateUtils";
-import Link from 'next/link';
+import { ActivityDatabase } from "@/models/activityDatabase";
 
-// declare the event prop that will get passed to the component
 interface EventCardProps {
     event: ActivityDatabase;
 }
 
-function HomeEventsCard({ event }: EventCardProps) {
+function HomeEventCard({ event }: EventCardProps) {
     const theme = useTheme();
-    const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
-    const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
+    const isTablet = useMediaQuery(theme.breakpoints.between("sm", "md"));
+    const isMobile = useMediaQuery(theme.breakpoints.between("xs", "sm"));
 
-    const { palette } = useTheme();
-
-    const darkImagePath = '/images/white_nsc_logo.png';
-    const lightImagePath = '/images/blue_nsc_logo.png';
-    const googlePlayImage = '/images/google_play.png'
-    const imagePath = palette.mode === "dark" ? darkImagePath : lightImagePath;
+    const { palette } = theme;
 
     return (
-        <Box sx={{ width: (isMobile || isTablet) ? "100vw" : "100%", display: "flex", flexDirection: "column", justifyContent: "center", p: 2 }}>
-            <Card sx={{ display: 'flex', flexDirection: 'row',  maxWidth: "700", minHeight: 300, minWidth: { md: 300, lg: 400, xl: 780 }, boxShadow: 2, borderRadius: 2, overflow: "hidden", }}>
+        <Box
+            sx={{
+                width: (isMobile || isTablet) ? "100vw" : "100%",
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+                p: 2,
+            }}
+        >
+            <Card
+                sx={{
+                    display: "flex",
+                    flexDirection: isMobile ? "column" : "row",
+                    borderRadius: 2,
+                    boxShadow: 2,
+                    overflow: "hidden",
+                    mb: 2,
+                }}
+            >
                 {!isMobile && (
                     <CardMedia
                         component="img"
-                        sx={{ height: "auto", objectFit: "cover", marginBlock: 2, marginLeft: 2, minWidth: 100, maxWidth: 200 }}
                         image={event.eventCoverPhoto}
                         alt={event.eventTitle}
+                        sx={{
+                            height: "auto",
+                            objectFit: "cover",
+                            marginBlock: 2,
+                            marginLeft: 2,
+                            minWidth: 100,
+                            maxWidth: 200,
+                        }}
                     />
                 )}
-                <CardContent sx={{ display: "flex", flexDirection: "column", width: "100%" }} >
+
+                <CardContent
+                    sx={{
+                        flex: 1,
+                        display: "flex",
+                        flexDirection: "column",
+                        p: 2,
+                        gap: 2,
+                        overflow: "hidden",
+                    }}
+                >
                     <Box
                         sx={{
-                        display: "flex",
-                        flexDirection: "row",
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                        width: "100%",
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "flex-start",
+                            gap: 2,
+                            flexWrap: "wrap",
+                            minWidth: 0, // prevent overflow from children
                         }}
                     >
-                        <Box sx={{ flexGrow: 1, mr: 2 }}>
+                        <Box sx={{ flex: 1, minWidth: 0 }}> {/* prevent overflow from children */}
                             <Link
-                                key={event._id}
-                                href={{
-                                    pathname: "/event-detail",
-                                    query: { id: event._id },
-                                }}
-                                style={{ textDecoration: "none" }} // prevent underline on header
+                                href={{ pathname: "/event-detail", query: { id: event._id } }}
+                                style={{ textDecoration: "none", display: "block" }}
                             >
-                                <CardHeader
-                                sx={{
-                                    width: "100%",
-                                    height: "100%",
-                                    minHeight: 60,
-                                    backgroundColor: palette.primary.dark,
-                                    color: palette.primary.contrastText,
-                                    borderRadius: 2,
-                                    boxShadow: 2,
-                                    padding: 1,
-                                    display: "flex",
-                                    alignItems: "center",
-                                }}
-                                title={
-                                    <Typography
+                                <Box
                                     sx={{
-                                        fontSize: isMobile || isTablet ? "1rem" : "1.5rem",
-                                        fontWeight: "300",
-                                        paddingLeft: 2,
-                                        fontFamily: "font-serif",
+                                        backgroundColor: palette.primary.dark,
+                                        color: palette.primary.contrastText,
+                                        borderRadius: 1,
+                                        px: 2,
+                                        py: 1,
+                                        mb: 1,
                                     }}
+                                >
+                                    <Typography
+                                        variant="h6"
+                                        fontWeight={500}
+                                        fontFamily="font-serif"
+                                        sx={{
+                                            whiteSpace: "normal",
+                                            overflowWrap: "break-word",
+                                            wordBreak: "break-word",
+                                            lineHeight: 1.3,
+                                        }}
                                     >
-                                    {event.eventTitle}
+                                        {event.eventTitle}
                                     </Typography>
-                                }
-                                />
+                                </Box>
                             </Link>
                         </Box>
 
-                        <Typography
-                        sx={{
-                            backgroundColor: palette.secondary.light,
-                            width: 60,
-                            height: 60,
-                            borderRadius: 2,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            fontWeight: "bolder",
-                            fontSize: 22,
-                            textAlign: "center",
-                        }}
+                        <Box
+                            sx={{
+                                backgroundColor: palette.secondary.light,
+                                width: 60,
+                                height: 60,
+                                borderRadius: 2,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                fontWeight: "bold",
+                                fontSize: 20,
+                                textAlign: "center",
+                                flexShrink: 0, // prevents the date box from shrinking
+                            }}
                         >
-                        {new Date(event.eventDate).toLocaleDateString("en-US", {
-                            month: "short",
-                            day: "numeric",
-                        })}
+                            {new Date(event.eventDate).toLocaleDateString("en-US", {
+                                month: "short",
+                                day: "numeric",
+                            })}
+                        </Box>
+                    </Box>
+
+                    <Box>
+                        <Typography fontFamily="font-serif">
+                            <strong>Location:</strong> {event.eventLocation}
+                        </Typography>
+                        <Typography fontFamily="font-serif">
+                            <strong>Time:</strong> {formatDate(event.eventDate)}
+                        </Typography>
+
+                        <Typography
+                            fontFamily="font-serif"
+                            mt={1}
+                            sx={{
+                                display: "-webkit-box",
+                                WebkitBoxOrient: "vertical",
+                                WebkitLineClamp: 3, // adjust if necessary
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",  
+                                height: "4.5rem", // fixed height for 3 lines
+                                wordBreak: "break-word", // allow word wrapping
+                            }}
+                        >
+                            <strong>Description:</strong> {event.eventDescription}
                         </Typography>
                     </Box>
-                    <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", width: "100%", height: "100%" }}>
-                        <Box sx={{ mb: 2 }}>
-                            <Box sx={{ mt: 2, mb: 2 }}>
-                                <Typography sx={{ fontWeight: "bold", display: "flex", flexDirection: "row", fontFamily: "font-serif" }}>
-                                    Location: {event.eventLocation}
-                                </Typography>
-                                <Typography sx={{ fontWeight: "bold", display: "flex", flexDirection: "row", fontFamily: "font-serif" }}>
-                                    Time: { formatDate(event.eventDate) }
-                                </Typography>
-                            </Box>
-                            <Typography sx={{ display: "flex", flexDirection: "column", fontFamily: "font-serif" }}>
-                                Description: {event.eventDescription}
-                            </Typography>
-                        </Box>
-                        <Box sx={{ display: "flex", flexDirection: "row", justifyContent: "space-between" }}>
-                            <Typography>
-                                Tags:
-                                {event.eventTags.map((tag, index) => (
-                                    <Box key={index} sx={{ backgroundColor: palette.secondary.light, borderRadius: 1, padding: '2px 6px', margin: '2px', display: 'inline-block', fontSize: 10, height: 20, fontWeight: "bold" }}>
-                                        {tag}
-                                    </Box>
-                                ))}
-                            </Typography>
-                        </Box>
+
+                    <Box mt="auto">
+                        <Typography>
+                            Tags:
+                            {event.eventTags.map((tag, index) => (
+                                <Box
+                                    key={index}
+                                    component="span"
+                                    sx={{
+                                        backgroundColor: palette.secondary.light,
+                                        borderRadius: 1,
+                                        px: 1,
+                                        py: 0.5,
+                                        ml: 1,
+                                        fontSize: 10,
+                                        height: 20,
+                                        fontWeight: "bold",
+                                        display: "inline-block",
+                                    }}
+                                >
+                                    {tag}
+                                </Box>
+                            ))}
+                        </Typography>
                     </Box>
                 </CardContent>
             </Card>
         </Box>
-    )
+    );
 }
 
+export default HomeEventCard;
 
-export default HomeEventsCard;
+
+

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -17,7 +17,7 @@ interface EventCardProps {
     event: ActivityDatabase;
 }
 
-function HomeEventCard({ event }: EventCardProps) {
+function HomeEventsCard({ event }: EventCardProps) {
     const theme = useTheme();
     const isTablet = useMediaQuery(theme.breakpoints.between("sm", "md"));
     const isMobile = useMediaQuery(theme.breakpoints.between("xs", "sm"));
@@ -193,7 +193,7 @@ function HomeEventCard({ event }: EventCardProps) {
     );
 }
 
-export default HomeEventCard;
+export default HomeEventsCard;
 
 
 

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -21,13 +21,15 @@ function HomeEventsCard({ event }: EventCardProps) {
     const theme = useTheme();
     const isTablet = useMediaQuery(theme.breakpoints.between("sm", "md"));
     const isMobile = useMediaQuery(theme.breakpoints.between("xs", "sm"));
+    const isSmallLaptop = useMediaQuery(theme.breakpoints.between("md", "lg"));
+
 
     const { palette } = theme;
 
     return (
         <Box
             sx={{
-                width: (isMobile || isTablet) ? "100vw" : "100%",
+                width: (isMobile || isTablet || isSmallLaptop) ? "100vw" : "100%",
                 display: "flex",
                 flexDirection: "column",
                 justifyContent: "center",
@@ -108,6 +110,12 @@ function HomeEventsCard({ event }: EventCardProps) {
                                             overflowWrap: "break-word",
                                             wordBreak: "break-word",
                                             lineHeight: 1.3,
+                                            display: "-webkit-box",
+                                            WebkitLineClamp: 2, // clamp to 2 lines, adjust if necessary
+                                            WebkitBoxOrient: "vertical",
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                            maxHeight: "3.5rem", // roughly 2 lines
                                         }}
                                     >
                                         {event.eventTitle}

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -43,7 +43,8 @@ function HomeEventsCard({ event }: EventCardProps) {
                     borderRadius: 2,
                     boxShadow: 2,
                     overflow: "hidden",
-                    mb: 2,
+                    marginLeft: isMobile || isTablet || isSmallLaptop ? 2 : 0,
+                    marginRight: isMobile || isTablet || isSmallLaptop ? 2 : 0,
                 }}
             >
                 {!isMobile && (

--- a/components/HomeEventsList.tsx
+++ b/components/HomeEventsList.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { Grid, Button, useMediaQuery, useTheme, Container, Box, Typography } from '@mui/material';
 import { ActivityDatabase } from "@/models/activityDatabase";
-import HomeEventsCard from "./HomeEventCard";
+import HomeEventsCard from "./HomeEventsCard";
 import { useFilteredEvents } from "@/utility/queries";
 import Link from "next/link";
 import TagSelector from "@/components/TagSelector";
@@ -83,7 +83,7 @@ export function HomeEventsList() {
                 {events.length > 0 ? (
                     events.map((event: ActivityDatabase) => (
                         <Grid key={event._id} size={12}>
-                            <HomeEventsCard key={event._id} event={event} />                            
+                            <HomeEventsCard key={event._id} event={event} />
                         </Grid>
                     ))
                 ) : (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@emotion/cache": "11.13.1",
-        "@emotion/react": "^11.14.0",
+        "@emotion/react": "11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "7.0.2",
         "@mui/material": "7.0.2",
@@ -41,7 +41,7 @@
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.2.0",
         "@types/jest": "29.5.14",
-        "@types/node": "^22.14.1",
+        "@types/node": "22.14.1",
         "@types/react-datepicker": "7.0.0",
         "@types/react-time-picker": "6.0.0",
         "eslint-plugin-jest-dom": "5.5.0",


### PR DESCRIPTION
<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** #651 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 This PR mainly fixes the overlapping issue between the home event cards on the homepage and also an added fix with layout and when users try to input long titles and descriptions.  
  - 👀 The home event cards are a little spaced out to help accommodate the overlapping issue and have better control of the component. When the window shrinks the event cards are no longer overlapping or resizing and are stable for mobile and tablet. When users have long titles or descriptions the event card will accommodate that as well and styles will not break.  
  - 🗨️ Only downside to the long titles and description fix is that the event card will get bigger because of it if the length of those titles and descriptions reach a certain point. This was added because I had noticed while testing that inputting long titles and descriptions will cause truncation and styles breaking with mainly the date getting cutoff and not appearing. If you guys have any suggestions on how to fix this issue I will take it and apply it, otherwise it's something we can come back to if needed.  

Would like feedback on the style changes if anything looks off, something should be removed or added, etc. If something is not clear style wise, I can try to explain it better if it needs more clarification.   

- **Changes:**
  - ✅ Added `spacing={4}` and `sx={{ px: 2 }}` to page.tsx on line 132 
  - ✅ Removed `maxWidth: "700", minHeight: 300, minWidth: { md: 300, lg: 400, xl: 780 }` from top card component as that was the main conflict causing the overlap.
  - ✅ Added `flex: 1 and minWidth: 0` to necessary box and card/cardcontent components to prevent overflow from children
  - ✅ Added style changes to title content and description content (mainly minor). Check the from lines 83 to 157 in the file changes to see all of the inline style changes to each component. Some style changes have comments to describe some of them.  
  - ✅ Added/Removed some minor styles from the tags section block below line 157. 
  - ✅ Added fixed height for cover photo in order to fit the event card at 250 
 
  - 🛠️ Mention breaking changes (if any) - NONE
  - 🔗 Link relevant discussions/issues - NONE
  - 📝 Additional info to assist developers & reviewers - NONE

UPDATE: Modified `HomeEventCard` to `HomeEventsCard` and `HomeEvents` to `HomeEventsList` to keep file consistency

## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

Demo of main overlap fix:
https://github.com/user-attachments/assets/ff1ff111-eb12-45a3-a00a-e3c7f10d449f

Demo of long title and description test:
https://github.com/user-attachments/assets/e6d0b4d5-0519-4871-92e6-0bbd9fab09e2

Screenshot of event picture with fixed size (original is 2000 x 2000 jpeg)
![image](https://github.com/user-attachments/assets/cdb1218d-b729-4aae-9e42-fed473c1b6f0)


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: clone both front-end and back-end branches for nsc events.
   - Step 2: setup .env file on both front and back with mongoDB and have several events (min 4) created on the homepage. Best way to do this is creating sample events in postman (can help if stuck with this step).
   - Step 3: run `npm install` on both front/back 
   - Step 4: start back-end server with `npm run start:dev`
   - Step 5: run front end by entering `npm run dev`
   - Step 6: shrink homepage to see results
   - Step 7 (Optional): create event with long title and description to replicate what you saw in the demo above (Demo of long title and description test). 
2. **Expected Behavior:** The event cards should not be overlapping and are stable when window gets smaller. events with long titles and descriptions are also handled well in the layout.  
3. **Actual Behavior (if bug):** the event cards with long titles and descriptions are handled well but have a small issue with the event card getting bigger, not sure if this can be fixed or not but maybe possible. Possible ticked to be added for next sprint 


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #651`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [x] **Squash commits** and enable **auto-merge** if approved.