### PR TITLE
nsc-events-nextjs_23_685-bug-event-card-grid-centering

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,7 +155,7 @@ const Home = () => {
           type="button"
           variant="contained"
           color="primary"
-          style={{ textTransform: "none", margin: "1em auto" }}
+          style={{ textTransform: "none", margin: "2em auto", }}
         >
           Load more events
         </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -129,11 +129,11 @@ const Home = () => {
           />
         )}
       </Box>
-      <Grid container spacing={4} sx={{ px: 2 }}> {/* Can be modified if needed (mx: 15)*/}
+      <Grid container spacing={4} sx={{ px: 2, width: '100%' }}> {/* Can be modified if needed (mx: 15)*/}
         {/* Display the events */}
         {events && events.length > 0 ? (
           events.map((event: ActivityDatabase) => (
-            <Grid size={{ md: 12, lg: 6 }} key={event._id} sx={{}}>
+            <Grid size={{ xs: 12, md: 12, lg: 6 }} key={event._id} sx={{}}>
               <HomeEventsCard event={event} />
             </Grid>
           ))

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -27,181 +27,184 @@ function HomeEventsCard({ event }: EventCardProps) {
     const { palette } = theme;
 
     return (
-        <Box
-            sx={{
-                width: (isMobile || isTablet || isSmallLaptop) ? "100vw" : "100%",
-                display: "flex",
-                flexDirection: "column",
-                justifyContent: "center",
-                p: 2,
-            }}
+      <Box
+        sx={{
+          width: "100%",
+          mx: "auto",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          p: 2,
+        }}
+      >
+        <Card
+          sx={{
+            display: "flex",
+            flexDirection: isMobile ? "column" : "row",
+            borderRadius: 2,
+            boxShadow: 2,
+            overflow: "hidden",
+            marginLeft: isMobile || isTablet || isSmallLaptop ? 2 : 0,
+            marginRight: isMobile || isTablet || isSmallLaptop ? 2 : 0,
+          }}
         >
-            <Card
-                sx={{
-                    display: "flex",
-                    flexDirection: isMobile ? "column" : "row",
-                    borderRadius: 2,
-                    boxShadow: 2,
-                    overflow: "hidden",
-                    marginLeft: isMobile || isTablet || isSmallLaptop ? 2 : 0,
-                    marginRight: isMobile || isTablet || isSmallLaptop ? 2 : 0,
-                }}
+          {!isMobile && (
+            <CardMedia
+              component="img"
+              image={event.eventCoverPhoto}
+              alt={event.eventTitle}
+              sx={{
+                height: 250, // fixed height of the image
+                objectFit: "cover",
+                marginBlock: 2,
+                marginLeft: 2,
+                minWidth: 100,
+                maxWidth: 200,
+              }}
+            />
+          )}
+
+          <CardContent
+            sx={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              p: 2,
+              gap: 2,
+              overflow: "hidden",
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "flex-start",
+                gap: 2,
+                flexWrap: "wrap",
+                minWidth: 0, // prevent overflow from children
+              }}
             >
-                {!isMobile && (
-                    <CardMedia
-                        component="img"
-                        image={event.eventCoverPhoto}
-                        alt={event.eventTitle}
-                        sx={{
-                            height: 250, // fixed height of the image
-                            objectFit: "cover",
-                            marginBlock: 2,
-                            marginLeft: 2,
-                            minWidth: 100,
-                            maxWidth: 200,
-                        }}
-                    />
-                )}
-
-                <CardContent
-                    sx={{
-                        flex: 1,
-                        display: "flex",
-                        flexDirection: "column",
-                        p: 2,
-                        gap: 2,
-                        overflow: "hidden",
-                    }}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                {" "}
+                {/* prevent overflow from children */}
+                <Link
+                  key={event._id}
+                  href={{
+                    pathname: "/event-detail",
+                    query: { id: event._id },
+                  }}
+                  style={{ textDecoration: "none", display: "block" }} // prevent underline on header
                 >
-                    <Box
-                        sx={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "flex-start",
-                            gap: 2,
-                            flexWrap: "wrap",
-                            minWidth: 0, // prevent overflow from children
-                        }}
+                  <Box
+                    sx={{
+                      backgroundColor: palette.primary.dark,
+                      color: palette.primary.contrastText,
+                      borderRadius: 1,
+                      px: 2,
+                      py: 1,
+                      mb: 1,
+                    }}
+                  >
+                    <Typography
+                      variant="h6"
+                      fontWeight={500}
+                      fontFamily="font-serif"
+                      sx={{
+                        whiteSpace: "normal",
+                        overflowWrap: "break-word",
+                        wordBreak: "break-word",
+                        lineHeight: 1.3,
+                        display: "-webkit-box",
+                        WebkitLineClamp: 2, // clamp to 2 lines, adjust if necessary
+                        WebkitBoxOrient: "vertical",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        maxHeight: "3.5rem", // roughly 2 lines
+                      }}
                     >
-                        <Box sx={{ flex: 1, minWidth: 0 }}> {/* prevent overflow from children */}
-                            <Link
-                                key={event._id}
-                                href={{ 
-                                    pathname: "/event-detail", 
-                                    query: { id: event._id } 
-                                }}
-                                style={{ textDecoration: "none", display: "block" }} // prevent underline on header
-                            >
-                                <Box
-                                    sx={{
-                                        backgroundColor: palette.primary.dark,
-                                        color: palette.primary.contrastText,
-                                        borderRadius: 1,
-                                        px: 2,
-                                        py: 1,
-                                        mb: 1,
-                                    }}
-                                >
-                                    <Typography
-                                        variant="h6"
-                                        fontWeight={500}
-                                        fontFamily="font-serif"
-                                        sx={{
-                                            whiteSpace: "normal",
-                                            overflowWrap: "break-word",
-                                            wordBreak: "break-word",
-                                            lineHeight: 1.3,
-                                            display: "-webkit-box",
-                                            WebkitLineClamp: 2, // clamp to 2 lines, adjust if necessary
-                                            WebkitBoxOrient: "vertical",
-                                            overflow: "hidden",
-                                            textOverflow: "ellipsis",
-                                            maxHeight: "3.5rem", // roughly 2 lines
-                                        }}
-                                    >
-                                        {event.eventTitle}
-                                    </Typography>
-                                </Box>
-                            </Link>
-                        </Box>
+                      {event.eventTitle}
+                    </Typography>
+                  </Box>
+                </Link>
+              </Box>
 
-                        <Box
-                            sx={{
-                                backgroundColor: palette.secondary.light,
-                                width: 60,
-                                height: 60,
-                                borderRadius: 2,
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                fontWeight: "bold",
-                                fontSize: 20,
-                                textAlign: "center",
-                                flexShrink: 0, // prevents the date box from shrinking
-                            }}
-                        >
-                            {new Date(event.eventDate).toLocaleDateString("en-US", {
-                                month: "short",
-                                day: "numeric",
-                                timeZone: "UTC",
-                            })}
-                        </Box>
-                    </Box>
+              <Box
+                sx={{
+                  backgroundColor: palette.secondary.light,
+                  width: 60,
+                  height: 60,
+                  borderRadius: 2,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontWeight: "bold",
+                  fontSize: 20,
+                  textAlign: "center",
+                  flexShrink: 0, // prevents the date box from shrinking
+                }}
+              >
+                {new Date(event.eventDate).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  timeZone: "UTC",
+                })}
+              </Box>
+            </Box>
 
-                    <Box>
-                        <Typography fontFamily="font-serif">
-                            <strong>Location:</strong> {event.eventLocation}
-                        </Typography>
-                        <Typography fontFamily="font-serif">
-                            <strong>Start Time:</strong> {event.eventStartTime}
-                            <br />
-                            <strong>End Time:</strong> {event.eventEndTime}
-                        </Typography>
+            <Box>
+              <Typography fontFamily="font-serif">
+                <strong>Location:</strong> {event.eventLocation}
+              </Typography>
+              <Typography fontFamily="font-serif">
+                <strong>Start Time:</strong> {event.eventStartTime}
+                <br />
+                <strong>End Time:</strong> {event.eventEndTime}
+              </Typography>
 
-                        <Typography
-                            fontFamily="font-serif"
-                            mt={1}
-                            sx={{
-                                display: "-webkit-box",
-                                WebkitBoxOrient: "vertical",
-                                WebkitLineClamp: 3, // adjust if necessary
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",  
-                                height: "4.5rem", // fixed height for 3 lines
-                                wordBreak: "break-word", // allow word wrapping
-                            }}
-                        >
-                            {event.eventDescription}
-                        </Typography>
-                    </Box>
+              <Typography
+                fontFamily="font-serif"
+                mt={1}
+                sx={{
+                  display: "-webkit-box",
+                  WebkitBoxOrient: "vertical",
+                  WebkitLineClamp: 3, // adjust if necessary
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  height: "4.5rem", // fixed height for 3 lines
+                  wordBreak: "break-word", // allow word wrapping
+                }}
+              >
+                {event.eventDescription}
+              </Typography>
+            </Box>
 
-                    <Box mt="auto">
-                        <Typography>
-                            Tags:
-                            {event.eventTags.map((tag, index) => (
-                                <Box
-                                    key={index}
-                                    component="span"
-                                    sx={{
-                                        backgroundColor: palette.secondary.light,
-                                        borderRadius: 1,
-                                        px: 1,
-                                        py: 0.5,
-                                        ml: 1,
-                                        fontSize: 10,
-                                        height: 20,
-                                        fontWeight: "bold",
-                                        display: "inline-block",
-                                    }}
-                                >
-                                    {tag}
-                                </Box>
-                            ))}
-                        </Typography>
-                    </Box>
-                </CardContent>
-            </Card>
-        </Box>
+            <Box mt="auto">
+              <Typography>
+                Tags:
+                {event.eventTags.map((tag, index) => (
+                  <Box
+                    key={index}
+                    component="span"
+                    sx={{
+                      backgroundColor: palette.secondary.light,
+                      borderRadius: 1,
+                      px: 1,
+                      py: 0.5,
+                      ml: 1,
+                      fontSize: 10,
+                      height: 20,
+                      fontWeight: "bold",
+                      display: "inline-block",
+                    }}
+                  >
+                    {tag}
+                  </Box>
+                ))}
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      </Box>
     );
 }
 

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -30,11 +30,11 @@ function HomeEventsCard({ event }: EventCardProps) {
       <Box
         sx={{
           width: "100%",
-          mx: "auto",
+          mx: "auto", // adjust the margin as needed
+          p: 0.5, // adjust the padding as needed
           display: "flex",
           flexDirection: "column",
           justifyContent: "center",
-          p: 2,
         }}
       >
         <Card
@@ -44,8 +44,6 @@ function HomeEventsCard({ event }: EventCardProps) {
             borderRadius: 2,
             boxShadow: 2,
             overflow: "hidden",
-            marginLeft: isMobile || isTablet || isSmallLaptop ? 2 : 0,
-            marginRight: isMobile || isTablet || isSmallLaptop ? 2 : 0,
           }}
         >
           {!isMobile && (
@@ -84,9 +82,7 @@ function HomeEventsCard({ event }: EventCardProps) {
                 minWidth: 0, // prevent overflow from children
               }}
             >
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                {" "}
-                {/* prevent overflow from children */}
+              <Box sx={{ flex: 1, minWidth: 0 }}> {/* prevent overflow from children */}
                 <Link
                   key={event._id}
                   href={{

--- a/components/HomeEventsList.tsx
+++ b/components/HomeEventsList.tsx
@@ -61,7 +61,7 @@ export function HomeEventsList() {
                 flexDirection={(isMobile || isTablet) ? "column" : "row"}
                 justifyContent="center"
                 alignItems="center"
-                sx={{ m: "auto" }}
+                sx={{ m: "auto", width: '100%' }}
             >
                 <Box marginY={5} maxWidth={'md'}>
                     {/* Toggle button to show/hide the TagSelector */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint": "8.57.1",
         "eslint-config-next": "14.2.14",
         "mongoose": "8.10.1",
-        "next": "^14.2.28",
+        "next": "14.2.28",
         "next-auth": "4.24.10",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -38,15 +38,15 @@
         "typescript": "5.6.3"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.2.0",
+        "@testing-library/jest-dom": "6.6.3",
+        "@testing-library/react": "16.2.0",
         "@types/jest": "29.5.14",
         "@types/node": "22.14.1",
         "@types/react-datepicker": "7.0.0",
         "@types/react-time-picker": "6.0.0",
         "eslint-plugin-jest-dom": "5.5.0",
         "eslint-plugin-testing-library": "6.4.0",
-        "jest": "^29.7.0",
+        "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "next-router-mock": "0.9.13",
         "ts-jest": "29.2.5"


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #685 

- **Summary:** 
Fix layout bug where:
- Event cards narrowed when fewer than five were rendered.
- Cards hugged the right edge on small screens.

- **Changes:**
  - ✅ List key changes made
  - `app/page.tsx` | Added `width: '100%'` to the outer `<Grid container>` 
  - `components/HomeEventsCard.tsx` | Set wrapper `<Box>` to `width: '100%'` and `mx: 'auto'` 
  - `components/HomeEventsList.tsx` | Same `width: '100%'` addition to the container grid 


## Screenshots / Visual Aids 🔎

https://github.com/user-attachments/assets/2971c46a-a6e1-4cfe-92c2-235bf305e531




## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Filter events so only 2–4 show → cards retain normal width.
   - Step 2: Switch to a mobile viewport (e.g., iPhone SE) → cards are centred, no flush-right edge.
2. **Expected Behavior:**
    * Cards keep consistent dimensions regardless of the number displayed.  
    * On `sm` and below, cards are centered with equal left/right padding
4. **Actual Behavior (if bug):**
    * shared on the issue

## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [X] **Squash commits** and enable **auto-merge** if approved.

