### PR TITLE
nsc-events-nextjs_24_688_route-event-cards-to-event-detail

### DIFF
--- a/app/profile/components/AttendedEvents.tsx
+++ b/app/profile/components/AttendedEvents.tsx
@@ -83,6 +83,7 @@ const EventCard: React.FC<EventCardProps> = ({
           </Typography>
         </Box>
       </Link>
+
       <Box
         sx={{
           display: "flex",

--- a/app/profile/components/AttendedEvents.tsx
+++ b/app/profile/components/AttendedEvents.tsx
@@ -15,6 +15,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { format } from "date-fns";
+import Link from "next/link";
 
 const URL = process.env.NSC_EVENTS_PUBLIC_API_URL!;
 
@@ -41,6 +42,7 @@ interface EventCardProps extends AttendedEvent {
 }
 
 const EventCard: React.FC<EventCardProps> = ({
+  eventId,
   eventTitle,
   eventDate,
   eventStartTime,
@@ -66,13 +68,21 @@ const EventCard: React.FC<EventCardProps> = ({
         flexDirection: "column",
       }}
     >
-      <Box sx={{ mb: 1 }}>
-        <Typography variant="h6">{eventTitle}</Typography>
-        <Typography variant="body2">
-          {date} at {eventStartTime}
-        </Typography>
-      </Box>
-
+      <Link
+        key={eventId}
+        href={{
+          pathname: "/event-detail",
+          query: { id: eventId },
+        }}
+        style={{ textDecoration: "none", display: "block" }}
+      >
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="h6">{eventTitle}</Typography>
+          <Typography variant="body2">
+            {date} at {eventStartTime}
+          </Typography>
+        </Box>
+      </Link>
       <Box
         sx={{
           display: "flex",
@@ -174,8 +184,8 @@ export const AttendedEvents: React.FC<AttendedEventsProps> = ({
   const confirmUnattend = async () => {
     if (!pendingEvent) {
       return;
-    }   
-    
+    }
+
     try {
       const res = await fetch(`${URL}/event-registration/unattend`, {
         method: "DELETE",

--- a/app/profile/components/AttendedEvents.tsx
+++ b/app/profile/components/AttendedEvents.tsx
@@ -83,7 +83,6 @@ const EventCard: React.FC<EventCardProps> = ({
           </Typography>
         </Box>
       </Link>
-
       <Box
         sx={{
           display: "flex",


### PR DESCRIPTION
## Please Expand to see visual change
## Summary & Changes 📃
- **Resolves:** #688 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 User can now see event details from attended event list.

- **Changes:**
  - ✅ Use existing eventId property and Link component to use event-detail route. 


## Screenshots / Visual Aids 🔎


<details>
  <summary> Expand ⬇️ </summary>
  

https://github.com/user-attachments/assets/d97efedd-da54-4000-83f4-18dbbc495d8f


</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Clone and run the front and back end.
   - Step 2: Log in as any user role that has attended event and go to the profile page.
   - Step 3: Click on an attended event.
2. **Expected Behavior:** You should be route to event-detail/id=[id]
3. **Actual Behavior (if bug):** You may get page rendering error because the eventId property of AttendedEvent can't be found or null. 


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [x] **Squash commits** and enable **auto-merge** if approved.

