### PR TITLE
 nsc-events-nextjs _24_690_fixed_height_sizing_on_image_tied_to_event

### DIFF
--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -52,7 +52,6 @@ function HomeEventsCard({ event }: EventCardProps) {
               image={event.eventCoverPhoto}
               alt={event.eventTitle}
               sx={{
-                height: 250, // fixed height of the image
                 objectFit: "cover",
                 marginBlock: 2,
                 marginLeft: 2,


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** `#690`

- **Summary:** (Briefly describe what this PR does)
  - The image wasn't using it's entire space in terms of height

- **Changes:**
  - Removing the height limit seemed to fix the issue


## Screenshots / Visual Aids 🔎
<details>
  <summary> Expand ⬇️ </summary>
![image](https://github.com/user-attachments/assets/c5a0e4fb-df7b-425d-a4a3-0c07d248aa60)
</details>


## How to Test 🧪
1. Create a new event with an image
2. Go to the homepage

## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

