### PR TITLE
nsc-events-nextjs_24_692_Added_date_with_proper_formatting

### DIFF
--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -152,7 +152,7 @@ function HomeEventsCard({ event }: EventCardProps) {
                 <strong>Location:</strong> {event.eventLocation}
               </Typography>
                 <Typography fontFamily="font-serif">
-                    <strong>Date:</strong>
+                    <strong>Date:&nbsp;</strong>
                     {new Date(event.eventDate).toLocaleDateString('en-US', {
                         year: 'numeric',
                         month: 'numeric',

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -156,6 +156,7 @@ function HomeEventsCard({ event }: EventCardProps) {
                         year: 'numeric',
                         month: 'numeric',
                         day: 'numeric',
+                        timeZone: 'UTC',
                     })}
                     <br/>
                     <strong>Start Time:</strong> {event.eventStartTime}

--- a/components/HomeEventsCard.tsx
+++ b/components/HomeEventsCard.tsx
@@ -151,13 +151,20 @@ function HomeEventsCard({ event }: EventCardProps) {
               <Typography fontFamily="font-serif">
                 <strong>Location:</strong> {event.eventLocation}
               </Typography>
-              <Typography fontFamily="font-serif">
-                <strong>Start Time:</strong> {event.eventStartTime}
-                <br />
-                <strong>End Time:</strong> {event.eventEndTime}
-              </Typography>
+                <Typography fontFamily="font-serif">
+                    <strong>Date:</strong>
+                    {new Date(event.eventDate).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'numeric',
+                        day: 'numeric',
+                    })}
+                    <br/>
+                    <strong>Start Time:</strong> {event.eventStartTime}
+                    <br/>
+                    <strong>End Time:</strong> {event.eventEndTime}
+                </Typography>
 
-              <Typography
+                <Typography
                 fontFamily="font-serif"
                 mt={1}
                 sx={{


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** `#692`

- **Summary:** 
- Adds date to event card formatted in the dd/mm/yyyy format

- **Changes:**
  - Added it to all event cards I could find


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>
  ![image](https://github.com/user-attachments/assets/01f6df2d-6206-4269-9f66-3a91fed1b841)
</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Create an event
   - See if date is on the event card on the homepage
2. **Expected Behavior:**
It should show the date on the event card
4. **Actual Behavior (if bug):** (Describe what happens instead)


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

