### PR TITLE
fix bug where coverPhoto has to be non empty to see the 'Edit Cover Photo' button

### DIFF
--- a/app/event-detail/page.tsx
+++ b/app/event-detail/page.tsx
@@ -418,7 +418,7 @@ const EventDetail = () => {
                   alt={event.eventTitle}
                   sx={{ height: "37vh", width: "100%", objectFit: "cover" }}
                 />
-                { event.eventCoverPhoto && (userRole === "admin" || (userRole === "creator" && event.createdByUser === userId)) && 
+                { (userRole === "admin" || (userRole === "creator" && event.createdByUser === userId)) && 
                   <Button
                     variant="contained"
                     color="primary"


### PR DESCRIPTION
Button was not showing for events that have an empty cover photo (which is empty by default on event creation).

The logic now only checks if the user is an admin OR if they are a creator AND the user who created that event.